### PR TITLE
docs(content-api): document Portable Text output format

### DIFF
--- a/content-api/get-page.mdx
+++ b/content-api/get-page.mdx
@@ -31,6 +31,10 @@ Returns the full page content including all component items. This is the primary
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `locale` | string | `""` | Locale code for localized content (e.g., `en-us`, `fr-fr`) |
+| `format` | `weaverse` \| `portable-text` | `weaverse` | Output format. See [Portable Text format](#portable-text-format) below. |
+| `meta` | boolean | `false` | When `true` *and* `format=portable-text`, each block carries a `_weaverse: { id, schemaVersion }` field for round-tripping back to the original Weaverse item. |
+
+The format can also be requested via the `Accept` header (`application/portable-text+json`). The query parameter takes precedence when both are present.
 
 ### Locale fallback
 
@@ -121,6 +125,104 @@ Each item in the `items` array represents a page section or component:
   The `items` array is a flat list. Use the `children` field on each item to reconstruct the component tree. The item with `type: "root"` is the tree's entry point.
 </Tip>
 
+## Portable Text format
+
+Pass `?format=portable-text` (or `Accept: application/portable-text+json`) to receive the page as a [Portable Text](https://www.portabletext.org/) array. This format is designed for multi-channel rendering (web, native, email, PDF) and AI consumption — rich-text fields are converted from opaque HTML strings into structured blocks that any [official PT renderer](https://www.portabletext.org/rendering/) can render.
+
+### Envelope difference
+
+The `items` field becomes `content`, and the response carries `Content-Type: application/portable-text+json`. All other envelope fields are unchanged.
+
+```json
+{
+  "object": "page",
+  "id": "clz5wxy12abc345defg",
+  "type": "PRODUCT",
+  "handle": "blue-shirt",
+  "locale": "en-us",
+  "content": [ /* Portable Text blocks — see below */ ],
+  "updatedAt": "2026-03-20T10:30:00.000Z",
+  "meta": { "inherited": false, "sourceProjectId": "...", "depth": 0 }
+}
+```
+
+### Mapping rules
+
+Each Weaverse item becomes a [custom Portable Text block](https://www.portabletext.org/specification/#custom-block-types):
+
+| Weaverse | Portable Text |
+|---|---|
+| `type` | `_type` |
+| `id` | `_key` (truncated to 8 chars; full id available in `_weaverse.id` when `?meta=true`) |
+| `data.*` fields | flattened onto the block root |
+| nested children | `children: PTBlock[]` on the parent block |
+| HTML-valued field (`richtext`) | array of [standard PT text blocks](https://www.portabletext.org/specification/#block) with `marks`, `markDefs`, `style`, `listItem` |
+| Synthetic `root` item | dropped — its children become the top-level `content` array |
+
+Field types other than `richtext` (text, image URL, color, range, switch, product/collection refs, etc.) pass through unchanged.
+
+### Example
+
+```json
+{
+  "content": [
+    {
+      "_type": "hero-banner",
+      "_key": "01950b17",
+      "backgroundImage": "https://cdn.shopify.com/hero.jpg",
+      "overlayOpacity": 40,
+      "children": [
+        { "_type": "heading", "_key": "01950c22", "text": "Summer 2026", "level": "h1" },
+        {
+          "_type": "text-section",
+          "_key": "01950d55",
+          "content": [
+            {
+              "_type": "block",
+              "_key": "b1",
+              "style": "normal",
+              "children": [
+                { "_type": "span", "_key": "s1", "text": "Read the " },
+                { "_type": "span", "_key": "s2", "text": "documentation", "marks": ["link1"] },
+                { "_type": "span", "_key": "s3", "text": " for details." }
+              ],
+              "markDefs": [
+                { "_type": "link", "_key": "link1", "href": "/docs" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Note how the `text-section`'s `content` field — originally an HTML string — is now a queryable array of PT blocks with explicit marks and link annotations.
+
+### Rendering with `@portabletext/react`
+
+```tsx
+import { PortableText } from '@portabletext/react'
+
+const components = {
+  types: {
+    'hero-banner': HeroBanner,
+    'heading': Heading,
+    'text-section': TextSection,
+  },
+  marks: {
+    link: ({ children, value }) => <a href={value.href}>{children}</a>,
+  },
+}
+
+function Page({ content }) {
+  return <PortableText value={content} components={components} />
+}
+```
+
+Official renderers exist for [React, Vue, Svelte, Astro, React Native](https://www.portabletext.org/rendering/) and more.
+
 ## Errors
 
 | Code | Status | When |
@@ -129,7 +231,7 @@ Each item in the `items` array represents a page section or component:
 | `FORBIDDEN` | 403 | API key does not have access to this project |
 | `PROJECT_NOT_FOUND` | 404 | Project does not exist or was deleted |
 | `PAGE_NOT_FOUND` | 404 | No page found for this type/handle (after locale fallback) |
-| `INVALID_PARAMS` | 400 | Missing `projectId`, `type`, or `handle` |
+| `INVALID_PARAMS` | 400 | Missing `projectId`, `type`, or `handle`, or unsupported `format` value |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |
 
 ## Examples

--- a/content-api/get-theme-settings.mdx
+++ b/content-api/get-theme-settings.mdx
@@ -31,6 +31,9 @@ When the `locale` query parameter is provided, also returns `staticTranslations`
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `locale` | string | No | Locale code (e.g., `fr-fr`, `vi-vn`). When provided, includes `staticTranslations` in the response. Tries exact match first, then falls back to language prefix (e.g., `fr`). |
+| `format` | `weaverse` \| `portable-text` | No (default `weaverse`) | Output format. With `portable-text`, any string value (in `theme` or `staticTranslations`) that contains HTML markup is replaced in place by a [Portable Text](https://www.portabletext.org/) block array. The envelope shape is unchanged. |
+
+The format can also be requested via `Accept: application/portable-text+json`. The query parameter takes precedence when both are present. See [Get Page › Portable Text format](/content-api/get-page#portable-text-format) for the conversion rules and a rendering example.
 
 ## Response
 
@@ -112,14 +115,44 @@ GET /projects/:projectId/theme-settings?locale=fr-fr
   Use the [List Languages](/content-api/list-languages) endpoint to discover available locales before requesting translations.
 </Tip>
 
+## Portable Text format
+
+With `?format=portable-text`, the response carries `Content-Type: application/portable-text+json` and any HTML-valued leaf inside `theme` or `staticTranslations` is converted in place. Non-HTML strings, numbers, booleans, colors, and the surrounding object structure are preserved exactly — only richtext leaves change shape.
+
+```json
+{
+  "object": "theme_settings",
+  "projectId": "clx1abc23def456ghij",
+  "theme": {
+    "colorSchemes": { "primary": { "background": "#ffffff" } },
+    "footer": {
+      "copyright": [
+        {
+          "_type": "block",
+          "_key": "b1",
+          "style": "normal",
+          "children": [
+            { "_type": "span", "_key": "s1", "text": "© 2026 " },
+            { "_type": "span", "_key": "s2", "text": "Acme Inc.", "marks": ["em"] }
+          ],
+          "markDefs": []
+        }
+      ]
+    }
+  }
+}
+```
+
+In the default `weaverse` format the same `copyright` field is returned as the original HTML string `"<p>&copy; 2026 <em>Acme Inc.</em></p>"`.
+
 ## Errors
 
 | Code | Status | When |
 |------|--------|------|
+| `INVALID_PARAMS` | 400 | Missing `projectId`, empty `locale`, or unsupported `format` value |
 | `UNAUTHORIZED` | 401 | Missing or invalid API key |
 | `FORBIDDEN` | 403 | API key does not have access to this project |
 | `PROJECT_NOT_FOUND` | 404 | Project does not exist or was deleted |
-| `INVALID_PARAMS` | 400 | Missing `projectId` |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |
 
 ## Examples

--- a/content-api/overview.mdx
+++ b/content-api/overview.mdx
@@ -28,6 +28,21 @@ https://studio.weaverse.io/api/v1/content
 | `GET` | [`/projects/:projectId/theme-settings`](/content-api/get-theme-settings) | Get theme settings |
 | `GET` | `/openapi.json` | OpenAPI 3.1 specification |
 
+## Response formats
+
+Page and theme-settings endpoints support two output formats. The default is unchanged — existing integrations are unaffected.
+
+| Format | How to request | Output shape |
+|---|---|---|
+| `weaverse` (default) | no parameter, or `?format=weaverse` | Flat item tree with `{id, type, data, children}` |
+| `portable-text` | `?format=portable-text`, or `Accept: application/portable-text+json` | [Portable Text](https://www.portabletext.org/) array, with rich-text fields converted from HTML strings to structured blocks |
+
+When both the query parameter and the `Accept` header are present, the query parameter wins. See [Get Page › Portable Text format](/content-api/get-page#portable-text-format) for the full mapping rules and a rendering example.
+
+<Tip>
+  Portable Text is well-suited for multi-channel rendering (web, native, email, PDF) and for piping content into LLMs, since the structured JSON is far easier to query and reason over than HTML strings.
+</Tip>
+
 ## Authentication
 
 All endpoints (except `/openapi.json`) require a **Content API key**. Pass it via the `Authorization` header:


### PR DESCRIPTION
Companion to **[weaverse-builder#2236](https://github.com/Weaverse/builder/pull/2236)** (closes [weaverse-builder#2208](https://github.com/Weaverse/builder/issues/2208)).

Documents the new opt-in `?format=portable-text` (and `Accept: application/portable-text+json`) output for the Content API page and theme-settings endpoints. Default behaviour is unchanged — these docs only add new sections for the new format.

## What changed

### `content-api/overview.mdx`
- New **Response formats** section right after the Endpoints table.
- Selection table (query param vs Accept header) and precedence note.
- Tip about multi-channel rendering + LLM use cases.

### `content-api/get-page.mdx`
- Added `format` and `meta` query parameters to the params table.
- New full **Portable Text format** section covering:
  - Envelope difference (`items` → `content`, new `Content-Type`)
  - Mapping rules table (item → PT block)
  - Worked example showing a richtext field with a link converted to PT spans + `markDefs`
  - Rendering snippet using `@portabletext/react`
- Updated `INVALID_PARAMS` error row to mention bad `format` values.

### `content-api/get-theme-settings.mdx`
- Added `format` query parameter row.
- New **Portable Text format** section with a worked example showing `<em>Acme Inc.</em>` → PT span with `marks: ['em']` and the envelope shape preserved.
- Removed a pre-existing duplicate `INVALID_PARAMS` error row.

## Verification

- Builds locally with Mintlify.
- All examples are valid Portable Text per the official spec.
- Snippet imports match the published `@portabletext/react` API.

## Merge ordering

Should ship in lock-step with [weaverse-builder#2236](https://github.com/Weaverse/builder/pull/2236). The Builder PR is what makes the documented `?format=portable-text` actually work — merging docs first means a brief window where the docs describe a feature that isn't live yet.
