### PR TITLE
docs: backfill 2026.5.4 changelog + fix overview endpoint table

### DIFF
--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -8,13 +8,10 @@ published: true
 
 Stay up-to-date with the latest features, improvements, and bug fixes across the entire Weaverse ecosystem.
 
-{/*
-DRAFT — next release entry. Fill in the version and date when the next builder release lands on `main`, then uncomment.
-
-<Update label="YYYY.M.D" description="Month D, YYYY" tags={["API", "Infrastructure"]}>
+<Update label="2026.5.6" description="May 6, 2026" tags={["API", "Infrastructure"]}>
   ### Bug Fixes
 
-  - **Content API `/openapi.json` 500**: The OpenAPI 3.1 spec endpoint was returning 500 because the YAML file it tried to read wasn't shipped in the production Docker image. The spec is now bundled directly into the route as JSON — the endpoint now serves the full spec, importable into Swagger UI / Postman / OpenAPI generators.
+  - **Content API `/openapi.json` 500**: The OpenAPI 3.1 spec endpoint was returning 500 because the YAML file it tried to read wasn't shipped in the production Docker image. The spec is now bundled directly into the route as JSON — the endpoint serves the full spec, importable into Swagger UI / Postman / OpenAPI generators.
   - **OpenAPI Spec Documents Portable Text Parameter**: The `?format=portable-text` query parameter (shipped in 2026.5.4) is now formally documented in the OpenAPI spec for both the page and theme-settings endpoints, including the alternative `Accept: application/portable-text+json` header and the optional `?meta=true` flag.
 
   ### Improvements
@@ -22,7 +19,6 @@ DRAFT — next release entry. Fill in the version and date when the next builder
   - **Security Updates**: Bumped `vite` 8.0.3 → 8.0.10, `lodash` 4.17.23 → 4.18.1, removed unused `uuid` dependency — closes 6 Dependabot alerts (3 high, 3 moderate)
   - **Deploy Reliability**: Production deploy workflow now uses `--wait-timeout 600` for Fly.io rollouts, preventing false-failure timeouts when one region's stopped machines take longer than the default 5-minute health-check window
 </Update>
-*/}
 
 <Update label="2026.5.5" description="May 4, 2026" tags={["Studio"]}>
   ### New Features

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -8,6 +8,22 @@ published: true
 
 Stay up-to-date with the latest features, improvements, and bug fixes across the entire Weaverse ecosystem.
 
+{/*
+DRAFT — next release entry. Fill in the version and date when the next builder release lands on `main`, then uncomment.
+
+<Update label="YYYY.M.D" description="Month D, YYYY" tags={["API", "Infrastructure"]}>
+  ### Bug Fixes
+
+  - **Content API `/openapi.json` 500**: The OpenAPI 3.1 spec endpoint was returning 500 because the YAML file it tried to read wasn't shipped in the production Docker image. The spec is now bundled directly into the route as JSON — the endpoint now serves the full spec, importable into Swagger UI / Postman / OpenAPI generators.
+  - **OpenAPI Spec Documents Portable Text Parameter**: The `?format=portable-text` query parameter (shipped in 2026.5.4) is now formally documented in the OpenAPI spec for both the page and theme-settings endpoints, including the alternative `Accept: application/portable-text+json` header and the optional `?meta=true` flag.
+
+  ### Improvements
+
+  - **Security Updates**: Bumped `vite` 8.0.3 → 8.0.10, `lodash` 4.17.23 → 4.18.1, removed unused `uuid` dependency — closes 6 Dependabot alerts (3 high, 3 moderate)
+  - **Deploy Reliability**: Production deploy workflow now uses `--wait-timeout 600` for Fly.io rollouts, preventing false-failure timeouts when one region's stopped machines take longer than the default 5-minute health-check window
+</Update>
+*/}
+
 <Update label="2026.5.5" description="May 4, 2026" tags={["Studio"]}>
   ### New Features
 
@@ -30,6 +46,24 @@ Stay up-to-date with the latest features, improvements, and bug fixes across the
   - **Zustand State Migration**: Studio state (page, locale, template assignment, device, sidebar) migrated from Preact Signals to Zustand for more consistent reactivity
   - **AI Proxy Migration**: Replaced `claudible.mtp.im` with `proxy.weaverse.ai` for AI traffic
   - **Claude Code GitHub Workflow**: Added an official Claude Code workflow for AI-assisted PR reviews
+</Update>
+
+<Update label="2026.5.4" description="May 2, 2026" tags={["API", "Studio"]}>
+  ### New Features
+
+  - **Portable Text Content API**: Opt-in `?format=portable-text` (and `Accept: application/portable-text+json`) on the page and theme-settings endpoints
+    - Default `weaverse` format unchanged — zero migration for existing integrations
+    - Rich-text fields convert from HTML strings to structured [Portable Text](https://www.portabletext.org/) blocks for multi-channel rendering and AI consumption
+    - Optional `?meta=true` on the page endpoint adds `_weaverse: { id, schemaVersion }` to each custom block for round-tripping
+    - See [Get Page › Portable Text format](/content-api/get-page#portable-text-format) for the full mapping
+
+  ### Bug Fixes
+
+  - **Multi-Store Studio 404**: Studio loader now resolves the active shop from the URL handle instead of `lastActiveStore`, fixing 404s when a user has multiple stores and switches between them
+
+  ### Improvements
+
+  - **Weaverse Proxy Cleanup**: Dropped dead exports and unused environment variables from the API proxy; added `aria-busy` to button loading states for screen-reader support
 </Update>
 
 <Update label="2026.4.22" description="April 22, 2026" tags={["Studio", "API"]}>

--- a/content-api/overview.mdx
+++ b/content-api/overview.mdx
@@ -26,6 +26,7 @@ https://studio.weaverse.io/api/v1/content
 | `GET` | [`/projects/:projectId/pages`](/content-api/list-pages) | List page assignments |
 | `GET` | [`/projects/:projectId/pages/:type/:handle`](/content-api/get-page) | Get page content |
 | `GET` | [`/projects/:projectId/theme-settings`](/content-api/get-theme-settings) | Get theme settings |
+| `GET` | [`/projects/:projectId/languages`](/content-api/list-languages) | List configured locales |
 | `GET` | `/openapi.json` | OpenAPI 3.1 specification |
 
 ## Response formats


### PR DESCRIPTION
Two small documentation gaps spotted while reviewing the docs repo.

## 1. `/projects/:projectId/languages` missing from the overview table

`content-api/list-languages.mdx` already exists and is in the sidebar nav, but the endpoint summary table in `content-api/overview.mdx` doesn't list it. New consumers reading the overview were missing one of the five GET endpoints.

## 2. `2026.5.4` skipped in the changelog

The previous batch changelog commit ([818f26f](https://github.com/Weaverse/docs/commit/818f26f18bc1e2154cc766d5de4261c9e4ec7910)) was titled `Add changelog entries for builder releases 2026.4.3 through 2026.5.5` but jumps straight from `2026.5.5` to `2026.4.22`, omitting `2026.5.4` entirely.

That release shipped:
- **Portable Text Content API** ([#2208](https://github.com/Weaverse/builder/issues/2208)) — user-visible API addition
- Multi-store studio 404 fix ([#2218](https://github.com/Weaverse/builder/issues/2218))
- Weaverse-proxy cleanup

The Portable Text addition in particular is worth a changelog entry because it's the first time the Content API has supported multiple output formats.

## 3. Pre-drafted next-release entry (commented out)

Added a commented-out `<Update>` block at the top of the changelog covering what's queued in `builder/dev` but not yet released to `main`:
- OpenAPI `/openapi.json` 500 fix ([#2237](https://github.com/Weaverse/builder/issues/2237) / [#2242](https://github.com/Weaverse/builder/pull/2242))
- Portable-text spec documentation ([#2243](https://github.com/Weaverse/builder/issues/2243) / [#2245](https://github.com/Weaverse/builder/pull/2245))
- Security bumps — vite/lodash/uuid ([#2244](https://github.com/Weaverse/builder/pull/2244)) closing 6 Dependabot alerts
- Deploy workflow `--wait-timeout 600` for Fly.io reliability

The block has placeholder `YYYY.M.D` / `Month D, YYYY` to fill in once the next builder release lands. Wrapped in JSX comments (`{/* ... */}`) so it doesn't render until uncommented.

## Risk

Zero — markdown only, no code. Mintlify build will validate.