### PR TITLE
docs(content-api): warn that locale must be passed for localized pages

### DIFF
--- a/content-api/get-page.mdx
+++ b/content-api/get-page.mdx
@@ -40,6 +40,30 @@ Returns the full page content including all component items. This is the primary
 
 The format can also be requested via the `Accept` header (`application/portable-text+json`). The query parameter takes precedence when both are present.
 
+<Warning>
+  **Always pass `locale` for localized projects.** Page content is stored per
+  locale. If you edit and publish a page while a specific market/locale is
+  selected in the editor (for example `en-us`), that content is saved on the
+  `en-us` assignment — **not** on the base locale (`""`).
+
+  Because `locale` defaults to `""`, calling
+  `…/pages/PRODUCT/default` *without* `?locale` returns the **base-locale**
+  page, which on a localized project is often a different — and possibly
+  empty or un-edited — assignment. This is the most common reason a published
+  change appears in the storefront/editor but seems "missing" from the API.
+
+  Fix: include the market locale, e.g.
+  `…/pages/PRODUCT/default?locale=en-us`.
+
+  To find which locale a product/page actually uses, open it in Studio — the
+  template dropdown shows the active template and "Assigned to N products",
+  and the market/locale selector sits next to it. The pair
+  `(type, handle, locale)` is exactly what you pass to this endpoint. You can
+  also confirm the available locales for each page with
+  [List Pages](/content-api/list-pages), which returns a `locale` field per
+  assignment.
+</Warning>
+
 ### Locale fallback
 
 When a page is not found for the requested locale, the API falls back in order:


### PR DESCRIPTION
## What
Add a `<Warning>` callout to the Content API **Get Page** docs explaining that `locale` must be passed for localized projects.

## Why
Content is stored per locale (`PageAssignment` keyed by `projectId, locale, type, handle`). When a page is edited/published with a market locale selected (e.g. `en-us`), the content saves to that locale's assignment, not the base locale (`""`). Because the API's `locale` query param defaults to `""`, calling `…/pages/PRODUCT/default` without `?locale` returns the base-locale page — a different, often empty/un-edited assignment on localized projects.

This caused a real customer escalation (PwC/Westside): the merchant published a field successfully, it showed in the storefront/editor, but the Content API "didn't show it" — purely because the request omitted `?locale=en-us`. Verified against the live project data that the edited content existed on the `en-us` assignment.

## Change
- `content-api/get-page.mdx`: add a `<Warning>` under Query parameters with the symptom, the fix (`?locale=en-us`), and how to find a page's locale/template (Studio template dropdown + List Pages `locale` field).

The existing "Locale fallback" section only covers not-found fallback; it didn't warn that the default `locale=""` resolves to a separate (possibly empty) assignment.
