### PR TITLE
docs(developer-tools): rewrite Weaverse MCP page for the unified server

### DIFF
--- a/developer-tools/weaverse-mcp.mdx
+++ b/developer-tools/weaverse-mcp.mdx
@@ -82,18 +82,30 @@ docs-only use) via the `env` block.
 
   <Tab title="OpenClaw">
     ```bash
-    claude mcp add weaverse \
+    openclaw mcp add weaverse \
       --env WEAVERSE_API_KEY=your-key \
       -- npx -y @weaverse/mcp
     ```
   </Tab>
 
-  <Tab title="VS Code / Codex">
-    Add to your client's MCP config:
+  <Tab title="Codex">
+    Codex CLI uses TOML, not JSON. Add to `~/.codex/config.toml`:
+
+    ```toml
+    [mcp_servers.weaverse]
+    command = "npx"
+    args = ["-y", "@weaverse/mcp"]
+    env = { WEAVERSE_API_KEY = "your-key" }
+    ```
+  </Tab>
+
+  <Tab title="VS Code">
+    Add to `.vscode/mcp.json` (or your user `mcp.json`). VS Code uses a top-level
+    `servers` key (not `mcpServers`):
 
     ```json
     {
-      "mcpServers": {
+      "servers": {
         "weaverse": {
           "command": "npx",
           "args": ["-y", "@weaverse/mcp"],

--- a/developer-tools/weaverse-mcp.mdx
+++ b/developer-tools/weaverse-mcp.mdx
@@ -80,11 +80,29 @@ docs-only use) via the `env` block.
     Restart Claude Desktop.
   </Tab>
 
-  <Tab title="OpenClaw">
+  <Tab title="Claude Code">
     ```bash
-    openclaw mcp add weaverse \
+    claude mcp add weaverse \
       --env WEAVERSE_API_KEY=your-key \
       -- npx -y @weaverse/mcp
+    ```
+  </Tab>
+
+  <Tab title="opencode">
+    opencode reads `opencode.json` (project) or
+    `~/.config/opencode/opencode.json` (global) with an `mcp` block:
+
+    ```json
+    {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
+        "weaverse": {
+          "type": "local",
+          "command": ["npx", "-y", "@weaverse/mcp"],
+          "environment": { "WEAVERSE_API_KEY": "your-key" }
+        }
+      }
+    }
     ```
   </Tab>
 
@@ -120,6 +138,12 @@ docs-only use) via the `env` block.
 <Note>
   Leave `WEAVERSE_API_KEY` out to run docs-only — `search_weaverse_docs` still
   works. Existing installs that only search docs keep working unchanged.
+</Note>
+
+<Note>
+  Using another MCP-compatible client — **pi**, Gemini CLI, or anything else that
+  speaks MCP? Point it at `npx -y @weaverse/mcp` and put `WEAVERSE_API_KEY` in
+  the server's environment.
 </Note>
 
 ## Authentication

--- a/developer-tools/weaverse-mcp.mdx
+++ b/developer-tools/weaverse-mcp.mdx
@@ -1,249 +1,239 @@
 ---
 title: "Weaverse MCP"
-description: "Connect AI tools to Weaverse documentation using the Model Context Protocol for accurate, contextual assistance"
+description: "Connect AI agents to Weaverse — search the docs and work with your own projects over the Content API — using the Model Context Protocol"
 published: true
 ---
 
 # Weaverse MCP
 
-Access Weaverse documentation and knowledge directly through your favorite AI tools with the Weaverse MCP server.
+The Weaverse MCP server connects AI tools (Cursor, Claude, Codex, and any other
+[Model Context Protocol](https://modelcontextprotocol.io) client) to Weaverse. It
+does two things:
 
-## About MCP Servers
+1. **Docs** — search the Weaverse documentation and knowledge base.
+2. **Your account** — read your own Weaverse projects, pages, theme settings, and
+   locales over the [Content API](/content-api/overview), scoped to your shop.
 
-The Model Context Protocol (MCP) is an open protocol that creates standardized connections between AI applications and external services, like documentation. The Weaverse MCP server enables AI assistants like Claude, Cursor, and others to search Weaverse documentation directly, delivering accurate, context-aware assistance for developers working with Weaverse products.
+Docs search is public. The account tools require an API key and only ever see the
+shop that key belongs to.
 
-Your MCP server exposes tools for AI applications to search the Weaverse knowledge base and find relevant information, code examples, API references, and implementation guides.
+## Two ways to connect
 
-## Accessing the Weaverse MCP Server
-
-The Weaverse MCP server is automatically hosted at:
-
-```
-https://docs.weaverse.io/mcp
-```
-
-This HTTP-based server is always available and requires no installation or setup. Simply connect your AI tools to this URL to start accessing Weaverse documentation.
+<CardGroup cols={2}>
+  <Card title="@weaverse/mcp (recommended)" icon="terminal">
+    The canonical server. Runs locally via `npx`, reads your API key from its
+    config, and exposes **both** the docs tools **and** the authenticated account
+    tools. Use this when you want your agent to work with your projects.
+  </Card>
+  <Card title="Hosted docs MCP" icon="globe">
+    `https://docs.weaverse.io/mcp` — a zero-install, HTTP-only server that exposes
+    **docs search only**. Good when all you need is documentation lookup. No
+    account access.
+  </Card>
+</CardGroup>
 
 <Note>
-  The MCP server is publicly available and automatically generated from the Weaverse documentation.
+  Both surfaces search the same documentation. `@weaverse/mcp` proxies that same
+  docs search and adds account tools on top, so it is a strict superset of the
+  hosted docs MCP.
 </Note>
 
-## Connecting to AI Tools
+## Install & configure `@weaverse/mcp`
 
-Connect the Weaverse MCP server to your preferred AI development tools:
+Add the server to your MCP client. Pass your API key (optional — omit it for
+docs-only use) via the `env` block.
 
 <Tabs>
-  <Tab title="Contextual Menu">
-    The easiest way to connect is using the contextual menu available on any documentation page:
-
-    1. Click the contextual menu icon (three dots) at the top of any page
-    2. Select one of the following options:
-       - **Copy MCP server URL** - Copies `https://docs.weaverse.io/mcp` to clipboard
-       - **Connect to Cursor** - Automatically installs the MCP server in Cursor
-       - **Connect to VS Code** - Automatically installs the MCP server in VS Code
-
-    This one-click integration automatically configures your development environment.
-  </Tab>
-
-  <Tab title="Claude Desktop">
-    To manually connect to Claude Desktop:
-
-    1. Open Claude Desktop settings
-    2. Locate the MCP configuration file:
-       - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-       - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-    3. Add the Weaverse MCP server configuration:
+  <Tab title="Cursor">
+    Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per-project):
 
     ```json
     {
       "mcpServers": {
         "weaverse": {
-          "url": "https://docs.weaverse.io/mcp"
+          "command": "npx",
+          "args": ["-y", "@weaverse/mcp"],
+          "env": { "WEAVERSE_API_KEY": "your-key" }
+        }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Claude Desktop">
+    Edit the config file:
+    - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+    - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+    ```json
+    {
+      "mcpServers": {
+        "weaverse": {
+          "command": "npx",
+          "args": ["-y", "@weaverse/mcp"],
+          "env": { "WEAVERSE_API_KEY": "your-key" }
         }
       }
     }
     ```
 
-    4. Restart Claude Desktop
-    5. The Weaverse MCP tools will now be available in your conversations
+    Restart Claude Desktop.
   </Tab>
 
-  <Tab title="Claude Code">
-    Claude Code automatically supports MCP servers through configuration:
-
-    1. Add the server URL to your Claude Code settings
-    2. Enter: `https://docs.weaverse.io/mcp`
-    3. The Weaverse documentation will be accessible in your coding sessions
-
-    Refer to the [Claude Code MCP guide](https://docs.anthropic.com/en/docs/build-with-claude/mcp) for detailed setup instructions.
+  <Tab title="OpenClaw">
+    ```bash
+    claude mcp add weaverse \
+      --env WEAVERSE_API_KEY=your-key \
+      -- npx -y @weaverse/mcp
+    ```
   </Tab>
 
-  <Tab title="Cursor">
-    To configure Cursor manually:
+  <Tab title="VS Code / Codex">
+    Add to your client's MCP config:
 
-    1. Open Cursor Settings (⌘/Ctrl + ,)
-    2. Navigate to **Extensions** > **MCPs**
-    3. Add a new MCP server with:
-       - **Name**: `weaverse`
-       - **URL**: `https://docs.weaverse.io/mcp`
-
-    Or use the contextual menu "Connect to Cursor" option for automatic setup.
-  </Tab>
-
-  <Tab title="VS Code">
-    To configure VS Code:
-
-    1. Install an MCP-compatible extension (e.g., Continue, Cody)
-    2. Add the Weaverse MCP server in your extension settings:
-       - **Server URL**: `https://docs.weaverse.io/mcp`
-
-    Or use the contextual menu "Connect to VS Code" option for automatic setup.
+    ```json
+    {
+      "mcpServers": {
+        "weaverse": {
+          "command": "npx",
+          "args": ["-y", "@weaverse/mcp"],
+          "env": { "WEAVERSE_API_KEY": "your-key" }
+        }
+      }
+    }
+    ```
   </Tab>
 </Tabs>
 
-## Available Tools
+<Note>
+  Leave `WEAVERSE_API_KEY` out to run docs-only — `search_weaverse_docs` still
+  works. Existing installs that only search docs keep working unchanged.
+</Note>
 
-The Weaverse MCP server provides the following tool:
+## Authentication
 
-<Card title="SearchWeaverse" icon="magnifying-glass">
-  Search across the Weaverse knowledge base to find relevant information, code examples, API references, and implementation guides.
+The server forwards `WEAVERSE_API_KEY` to the Content API as
+`Authorization: Bearer <key>`. It never validates or stores the token itself —
+the Content API enforces shop scoping and scopes. An account tool called without
+a valid, sufficiently-scoped key returns a clear auth error, never data.
 
-  **Use when you need to**:
-  - Answer questions about Weaverse features
-  - Find specific documentation or code examples
-  - Understand how features work
-  - Locate API references and implementation details
-  - Troubleshoot issues
+<Steps>
+  <Step title="Get a key">
+    Today: create a Content API key in **[Weaverse Dashboard → Settings →
+    API Keys](https://studio.weaverse.io)**.
 
-  **Returns**: Contextual content with titles and direct links to documentation pages
+    Coming soon: your agent can obtain a scoped, expiring `agent_cli` token via
+    the **device handshake** — the agent starts the flow, you approve it once in
+    Builder, and the agent stores the key.
+  </Step>
+  <Step title="Add it to your MCP config">
+    Put it in the `env` block as shown above.
+  </Step>
+  <Step title="Confirm">
+    Ask your agent to run `whoami`. It returns the projects the key can access
+    (and its shop id + scopes once the handshake ships).
+  </Step>
+</Steps>
+
+### Scopes & shop isolation
+
+Account tools map to Content API scopes (`content:read` for the read tools). Each
+key is scoped to a single Weaverse shop — requests can only touch that shop's
+projects, and reaching across shops returns a `403`-style error. Tokens are
+revocable any time from **Settings → Connected agents / API keys** in Builder.
+
+## Available tools
+
+### Docs (public — no API key)
+
+<Card title="search_weaverse_docs" icon="magnifying-glass">
+  Search the Weaverse knowledge base for features, schema/input settings, SDK
+  hooks, theme settings, and implementation guides. Returns titles, direct links,
+  and content. Also registered as `search_docs`.
+
+  Backed by the official Weaverse documentation MCP (hosted by Mintlify) — the
+  knowledge base, ranking, and freshness all live upstream.
 </Card>
 
-## Common Use Cases
+### Account (read-only — requires `WEAVERSE_API_KEY`)
 
-The Weaverse MCP is particularly useful for:
+| Tool | Description |
+| ---- | ----------- |
+| `whoami` | Identify the token: shop id + scopes (when available) and the projects it can access. Call first. |
+| `list_projects` | List the projects in your shop (cursor-paginated). |
+| `list_pages` | List pages in a project (filter by `type` / `locale`). |
+| `get_page` | Get a page's content. Defaults to **Portable Text**; pass `format: "weaverse"` for the raw item tree. |
+| `get_theme_settings` | Get a project's theme settings (design tokens + config). |
+| `list_languages` | List a project's locales. |
 
-<CardGroup cols={2}>
-  <Card title="Component Development" icon="cube">
-    Ask about creating custom Weaverse components, schema definitions, and input settings
-  </Card>
+<Tip>
+  `get_page` returns [Portable Text](/content-api/get-page#portable-text-format)
+  by default — structured JSON that is far easier for an LLM to reason over than
+  raw HTML strings.
+</Tip>
 
-  <Card title="API Integration" icon="plug">
-    Query specific API hooks, component props, and utility functions
-  </Card>
+## Content writes & safety
 
-  <Card title="Troubleshooting" icon="wrench">
-    Share error messages to receive relevant documentation and solutions
-  </Card>
+<Warning>
+  The Content API is **read-only today**, so the MCP exposes **no write tools**.
+</Warning>
 
-  <Card title="Implementation Guidance" icon="map">
-    Get step-by-step instructions for implementing Weaverse features
-  </Card>
-</CardGroup>
+When write endpoints land, the planned tools (e.g. `update_page_content`,
+`update_theme_settings`) will be **bulk edits to existing items only** and will
+ship behind a safety flow:
 
-### Example Queries
+- **Dry-run by default** — return a diff/preview first.
+- **`confirm: true` required** to apply.
+- **Audit log** of which token changed what, when.
 
-Here are some example questions you can ask your AI assistant with the Weaverse MCP enabled:
+**Destructive and account-level operations are never exposed via MCP** — deleting
+projects, billing, team/members, plan changes, and production publishes stay
+human-only in [Weaverse Builder](https://studio.weaverse.io). An agent may
+*propose*; a human *confirms*.
 
-```
-How do I set up a new Weaverse Hydrogen theme?
+## How docs search relates to `docs.weaverse.io/mcp`
 
-What's the difference between 'settings' and 'inspector' in component schemas?
+`https://docs.weaverse.io/mcp` is the Mintlify-hosted, docs-only MCP (it resolves
+to `https://weaverse.io/docs/mcp`). `@weaverse/mcp` proxies that exact docs search
+and layers the account tools on top. Pick the hosted URL for a zero-install docs
+lookup; pick `@weaverse/mcp` when you want your agent to work with your projects.
 
-How do I use the createSchema() function?
-
-Show me examples of the useWeaverse hook
-
-What are the available input types for component settings?
-
-How do I implement data fetching in a Weaverse section?
-
-What props does the WeaverseRoot component accept?
-```
-
-## How It Works
-
-When you ask a question about Weaverse in your AI tool:
-
-1. **Recognition**: The AI assistant recognizes your question is about Weaverse
-2. **Query**: It calls the Weaverse MCP server with your query
-3. **Search**: The MCP server searches the Weaverse documentation using the SearchWeaverse tool
-4. **Return**: Relevant documentation with links is returned to the AI assistant
-5. **Response**: The AI formulates an accurate response based on official documentation
-
-This process ensures responses are accurate and based on the latest Weaverse documentation.
-
-## Benefits
+## Related
 
 <CardGroup cols={2}>
-  <Card title="Always Accurate" icon="check">
-    AI assistants access the most up-to-date Weaverse documentation
+  <Card title="Content API" icon="plug" href="/content-api/overview">
+    The read-only REST API the account tools wrap. The MCP is its agent-native front end.
   </Card>
-
-  <Card title="Context-Aware" icon="brain">
-    Get answers tailored to Weaverse's specific implementation and ecosystem
+  <Card title="Shopify Hydrogen Skills" icon="sparkles" href="/developer-tools/shopify-hydrogen-skills">
+    Agent skills for building Weaverse + Hydrogen storefronts. After setup, the same key powers the account tools here.
   </Card>
-
-  <Card title="Instant Setup" icon="bolt">
-    No installation required - just connect and start using
+  <Card title="Weaverse CLI" icon="terminal" href="/developer-tools/weaverse-cli">
+    Project setup and theme scaffolding.
   </Card>
-
-  <Card title="Seamless Integration" icon="link">
-    Works with Claude, Cursor, VS Code, and other MCP-compatible tools
+  <Card title="Weaverse SDKs" icon="code" href="/developer-tools/weaverse-sdks">
+    Build custom components for Weaverse Hydrogen themes.
   </Card>
 </CardGroup>
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="MCP server not responding" icon="circle-exclamation">
-    - Verify your internet connection
-    - Check that the URL is exactly: `https://docs.weaverse.io/mcp`
-    - Ensure your AI tool's MCP configuration is correct
-    - Try disconnecting and reconnecting the MCP server
+  <Accordion title="Account tools return an authentication error" icon="key">
+    - Confirm `WEAVERSE_API_KEY` is set in the server's `env` block.
+    - Verify the key in **Weaverse Dashboard → Settings → API Keys** (not revoked).
+    - Docs tools work without a key; only the account tools need one.
   </Accordion>
-
-  <Accordion title="Getting irrelevant results" icon="magnifying-glass">
-    - Be specific in your queries
-    - Include Weaverse-specific terms (e.g., "createSchema", "WeaverseRoot", "input settings")
-    - Mention the specific feature or component you're asking about
-    - Try rephrasing your question with more context
+  <Accordion title="“Access denied” on a project" icon="lock">
+    - The key is scoped to one shop. You can only access that shop's projects.
+    - Use `list_projects` / `whoami` to see exactly what the key can reach.
   </Accordion>
-
-  <Accordion title="Connection issues" icon="plug">
-    - Verify the MCP server URL is correctly configured
-    - Restart your AI tool after adding the configuration
-    - Check your tool's MCP documentation for setup requirements
-    - Ensure your firewall allows connections to docs.weaverse.io
+  <Accordion title="Server won't start" icon="circle-exclamation">
+    - Ensure Node.js is installed and `npx -y @weaverse/mcp` can run.
+    - Restart your AI tool after editing its MCP config.
+    - The server logs a startup line to stderr noting whether account tools are enabled.
   </Accordion>
-
-  <Accordion title="Tools not showing up" icon="tools">
-    - Confirm the MCP server is connected in your tool's settings
-    - Restart your AI application
-    - Check that your tool supports HTTP-based MCP servers
-    - Verify you're using a compatible version of your AI tool
+  <Accordion title="No docs results" icon="magnifying-glass">
+    - Be specific and use Weaverse terms (e.g. `createSchema`, `WeaverseRoot`, "input settings").
+    - Docs search requires network access to the hosted documentation MCP.
   </Accordion>
 </AccordionGroup>
-
-## Next Steps
-
-<CardGroup cols={2}>
-  <Card title="Weaverse CLI" icon="terminal" href="/developer-tools/weaverse-cli">
-    Learn about the Weaverse CLI for project setup and theme scaffolding
-  </Card>
-
-  <Card title="Weaverse SDKs" icon="code" href="/developer-tools/weaverse-sdks">
-    Explore the Weaverse SDKs for building custom components
-  </Card>
-
-  <Card title="API Reference" icon="book" href="/api-reference/introduction">
-    Browse the complete Weaverse API documentation
-  </Card>
-
-  <Card title="Development Guide" icon="wrench" href="/development-guide/index">
-    Start building with Weaverse Hydrogen themes
-  </Card>
-</CardGroup>
-
-<Note>
-  The Weaverse MCP server is continuously updated as documentation evolves, ensuring your AI tools always have access to the latest information.
-</Note>

--- a/developer-tools/weaverse-mcp.mdx
+++ b/developer-tools/weaverse-mcp.mdx
@@ -193,6 +193,14 @@ revocable any time from **Settings → Connected agents / API keys** in Builder.
 
 ### Account (read-only — requires `WEAVERSE_API_KEY`)
 
+<Note>
+  **Account tools require `@weaverse/mcp` v2.2.0 or later** (the unified server,
+  shipped with this release). Documentation search works on every version.
+  Because `npx -y @weaverse/mcp` always fetches the latest, a fresh install
+  gets the account tools automatically; pin or upgrade if you installed an older
+  version.
+</Note>
+
 | Tool | Description |
 | ---- | ----------- |
 | `whoami` | Identify the token: shop id + scopes (when available) and the projects it can access. Call first. |


### PR DESCRIPTION
Rewrites `developer-tools/weaverse-mcp.mdx` for the new unified `@weaverse/mcp` server (see `Weaverse/mcp-server#1`).

Covers:
- `npx @weaverse/mcp` config (Cursor / Claude Desktop / OpenClaw / VS Code) with `WEAVERSE_API_KEY`.
- Authentication: how to get a key, scopes (`content:read`), shop isolation, revocation.
- Tools: docs search (public) + read-only account tools (`whoami`, `list_projects`, `list_pages`, `get_page` Portable-Text default, `get_theme_settings`, `list_languages`).
- Write-safety: read-only today; planned writes are dry-run → confirm + audit; **destructive/account-level ops stay Builder-only**.
- The relationship between the hosted `docs.weaverse.io/mcp` (docs-only) and the canonical `@weaverse/mcp` (docs + account).
- Cross-links to the Content API overview and the Shopify Hydrogen skills.

Page slug unchanged (`developer-tools/weaverse-mcp`), so no redirect entry needed.