### PR TITLE
docs: fix all broken internal links flagged by mint broken-links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ published: true  # Optional, defaults to true
 
 Commonly used Mintlify components in this documentation:
 
-```mdx
+````mdx
 # Card components
 <Card title="Title" icon="icon-name" href="/path">
   Description text
@@ -206,7 +206,7 @@ npm run dev
 <Frame>
   <img src="url" alt="description" />
 </Frame>
-```
+````
 
 ## Weaverse-Specific Terminology
 

--- a/api-reference/get-selected-product-options.mdx
+++ b/api-reference/get-selected-product-options.mdx
@@ -109,4 +109,4 @@ Note that the `isDesignMode` parameter has been automatically filtered out.
 
 - [Shopify Hydrogen's getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/2025-01/utilities/getselectedproductoptions) - Original implementation that this function extends
 - [Shopify's Storefront API Product Variants](https://shopify.dev/docs/api/storefront/latest/objects/productvariant)
-- [WeaverseHydrogenRoot](/api-reference/weaverse-hydrogen-root) - For rendering product content with the selected variant
+- [WeaverseHydrogenRoot](/api-reference/weaverse-root) - For rendering product content with the selected variant

--- a/api-reference/types.mdx
+++ b/api-reference/types.mdx
@@ -350,7 +350,7 @@ declare module '@shopify/hydrogen' {
 
 ## Related
 
-- [WeaverseHydrogenRoot](/api-reference/weaverse-hydrogen-root) - The main component that uses these types
+- [WeaverseHydrogenRoot](/api-reference/weaverse-root) - The main component that uses these types
 - [WeaverseClient](/api-reference/weaverse-client) - Client for fetching Weaverse content
 
 ### Component Schema

--- a/api-reference/use-theme-settings.mdx
+++ b/api-reference/use-theme-settings.mdx
@@ -126,5 +126,5 @@ Theme settings are initially loaded from your Weaverse project through the `Weav
 ## Related
 
 - [withWeaverse](/api-reference/with-weaverse) - HOC that sets up the theme settings provider
-- [Global Theme Settings](/guides/global-theme-settings) - Guide to configuring global theme settings
-- [WeaverseHydrogenRoot](/api-reference/weaverse-hydrogen-root) - Main component that initializes Weaverse
+- [Global Theme Settings](/development-guide/styling-theming#global-theme-settings) - Guide to configuring global theme settings
+- [WeaverseHydrogenRoot](/api-reference/weaverse-root) - Main component that initializes Weaverse

--- a/api-reference/weaverse-root.mdx
+++ b/api-reference/weaverse-root.mdx
@@ -103,5 +103,5 @@ export default function Page() {
 ## Related
 
 - [useWeaverse](/api-reference/use-weaverse) - Hook to access the Weaverse instance
-- [WeaverseHydrogenRoot](/api-reference/weaverse-hydrogen-root) - Hydrogen-specific wrapper around WeaverseRoot
+- WeaverseHydrogenRoot - Hydrogen-specific wrapper around WeaverseRoot
 - [useItemInstance](/api-reference/use-item-instance) - Access component instances in the tree

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -96,7 +96,7 @@ Stay up-to-date with the latest features, improvements, and bug fixes across the
 
   - **Translation Feature Launch**: Rolled out the full translation system to production
     - Manage translated content per locale across pages and theme settings
-    - See the [translation guide](/features/translation) for setup details
+    - See the [translation guide](/features/translation-feature-guide) for setup details
 
   ### Improvements
 

--- a/development-guide/input-settings.mdx
+++ b/development-guide/input-settings.mdx
@@ -710,7 +710,7 @@ After using the Resource Picker inputs, you might notice that the returned data 
 
 This is where the **Weaverse** client comes in handy. Using its **`storefront.query`** function, you can fetch the full set of data related to your selection from [Shopify's Storefront API](https://shopify.dev/docs/api/storefront).
 
-To learn more about how to effectively fetch and utilize data within Weaverse, refer to our dedicated section on [Data Fetching & Caching](/guides/data-fetching-and-caching#querying-storefront-data-inside-weaverses-component).
+To learn more about how to effectively fetch and utilize data within Weaverse, refer to our dedicated section on [Data Fetching & Caching](/development-guide/data-fetching#shopify-storefront-api).
 
 ## Resource Picker Inputs
 
@@ -913,7 +913,7 @@ After using the Resource Picker inputs, you might notice that the returned data 
 
 This is where the **Weaverse** client comes in handy. Using its **`storefront.query`** function, you can fetch the full set of data related to your selection from [Shopify's Storefront API](https://shopify.dev/docs/api/storefront).
 
-To learn more about how to effectively fetch and utilize data within Weaverse, refer to our dedicated section on [Data Fetching & Caching](/guides/data-fetching-and-caching#querying-storefront-data-inside-weaverses-component).
+To learn more about how to effectively fetch and utilize data within Weaverse, refer to our dedicated section on [Data Fetching & Caching](/development-guide/data-fetching#shopify-storefront-api).
 
 ## Next Steps
 

--- a/hydrogen-themes/index.mdx
+++ b/hydrogen-themes/index.mdx
@@ -28,10 +28,10 @@ Our flagship starter theme showcasing Weaverse's capabilities:
 
 ## Creating Themes
 
-### [Theme Development Guide](/hydrogen-themes/creating-themes)
+### [Theme Development Guide](/development-guide/index)
 Complete guide to building your own Weaverse theme from scratch.
 
-### [Theme Marketplace](/hydrogen-themes/theme-marketplace)
+### Theme Marketplace
 Learn how to submit and share your themes with the community.
 
 ## Theme Architecture
@@ -69,8 +69,8 @@ When creating themes, follow these best practices:
 ## Getting Started
 
 1. **Explore**: Check out the [Pilot theme](/hydrogen-themes/pilot-theme-overview)
-2. **Learn**: Follow the [Theme Development Guide](/hydrogen-themes/creating-themes)
+2. **Learn**: Follow the [Theme Development Guide](/development-guide/index)
 3. **Build**: Create your own theme using our [Development Guide](/development-guide/index)
-4. **Share**: Submit to the [Theme Marketplace](/hydrogen-themes/theme-marketplace)
+4. **Share**: Submit to the Theme Marketplace
 
 Ready to start building? Check out our [Getting Started guide](getting-started) to set up your development environment!

--- a/hydrogen-themes/pilot-theme-overview.mdx
+++ b/hydrogen-themes/pilot-theme-overview.mdx
@@ -52,7 +52,7 @@ Pilot includes a variety of pre-built sections to help you build pages quickly:
 
 ---
 
-Pilot offers extensive global theme settings for site-wide customization. Learn more about configuring these options in our [Global Theme Settings](/guides/global-theme-settings) guide.
+Pilot offers extensive global theme settings for site-wide customization. Learn more about configuring these options in our [Global Theme Settings](/development-guide/styling-theming#global-theme-settings) guide.
 
 ## Using Metaobjects with Pilot
 

--- a/resources/index.mdx
+++ b/resources/index.mdx
@@ -18,7 +18,7 @@ Complete 45-minute guide to building your first Weaverse Hydrogen store with mod
 ### [FAQ](resources/faq)
 Frequently asked questions, common issues, and debugging strategies.
 
-### [Glossary](resources/glossary)
+### Glossary
 Definitions of Weaverse and Shopify Hydrogen terminology.
 
 ## Quick References
@@ -90,8 +90,8 @@ Pre-launch verification steps for production deployments.
 
 Want to contribute to Weaverse? Check out:
 
-- [Contributing Guidelines](community/contributing)
-- [Code of Conduct](community/code-of-conduct)
-- [Feature Request Process](community/feature-requests)
+- [Contributing Guidelines](/community/community#contribution-guidelines)
+- [Code of Conduct](/community/community#code-of-conduct)
+- [Feature Request Process](/community/community#getting-involved)
 
 Find what you need or can't find something? Let us know in our [Slack community](https://wvse.cc/weaverse-slack)!


### PR DESCRIPTION
## What

Fixes all **18 broken internal links across 10 files** that `mint broken-links` reports. These are pre-existing on `main` (surfaced while reviewing #24, unrelated to that quickstart change).

`mint broken-links` → **success, no broken links found** after this change.

## Decisions

**Repointed to the correct existing page:**

| Broken target | New target |
|---|---|
| `/api-reference/weaverse-hydrogen-root` (×3 cross-refs) | `/api-reference/weaverse-root` — the actual root-component doc |
| `/guides/global-theme-settings` (×2) | `/development-guide/styling-theming#global-theme-settings` |
| `/features/translation` | `/features/translation-feature-guide` |
| `/guides/data-fetching-and-caching#…` (×2) | `/development-guide/data-fetching#shopify-storefront-api` |
| `/hydrogen-themes/creating-themes` (×2) | `/development-guide/index` |
| `community/contributing` | `/community/community#contribution-guidelines` |
| `community/code-of-conduct` | `/community/community#code-of-conduct` |
| `community/feature-requests` | `/community/community#getting-involved` |

**De-linked (no target page exists; descriptive text kept):**

- `/hydrogen-themes/theme-marketplace` — no marketplace page
- `resources/glossary` — no glossary page
- `WeaverseHydrogenRoot` self-reference in `weaverse-root.mdx` — would link to itself

**Code fence fix:**

- `CLAUDE.md` — the Mintlify-components example used a ```` ```mdx ```` fence containing a nested ```` ```bash ```` block, which closed the outer fence early and leaked the `<img src="url" />` sample as a real (broken) image link. Switched the outer fence to 4 backticks so the whole example stays a code block.

If any de-link should instead become a real page (e.g. a Glossary or Theme Marketplace), happy to follow up.
