### PR TITLE
docs: add Glossary page; redirect deprecated Theme Marketplace to live gallery

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -238,7 +238,8 @@
 						"pages": [
 							"resources/faq",
 							"resources/tutorial",
-							"resources/example-components"
+							"resources/example-components",
+							"resources/glossary"
 						]
 					},
 					{

--- a/hydrogen-themes/index.mdx
+++ b/hydrogen-themes/index.mdx
@@ -31,8 +31,8 @@ Our flagship starter theme showcasing Weaverse's capabilities:
 ### [Theme Development Guide](/development-guide/index)
 Complete guide to building your own Weaverse theme from scratch.
 
-### Theme Marketplace
-Learn how to submit and share your themes with the community.
+### [Theme Gallery](https://weaverse.io/themes)
+Browse the official gallery of ready-to-use Weaverse Hydrogen themes.
 
 ## Theme Architecture
 
@@ -71,6 +71,6 @@ When creating themes, follow these best practices:
 1. **Explore**: Check out the [Pilot theme](/hydrogen-themes/pilot-theme-overview)
 2. **Learn**: Follow the [Theme Development Guide](/development-guide/index)
 3. **Build**: Create your own theme using our [Development Guide](/development-guide/index)
-4. **Share**: Submit to the Theme Marketplace
+4. **Share**: Share your theme with the [community](/community/community)
 
 Ready to start building? Check out our [Getting Started guide](getting-started) to set up your development environment!

--- a/resources/glossary.mdx
+++ b/resources/glossary.mdx
@@ -1,0 +1,71 @@
+---
+title: "Glossary"
+description: "Definitions of the Weaverse and Shopify Hydrogen terminology used throughout these docs."
+published: true
+---
+
+# Glossary
+
+Definitions of the Weaverse and Shopify Hydrogen terms used throughout this documentation. Each term links to the guide where the concept is covered in depth.
+
+## Platform & Core Concepts
+
+- **Weaverse** — A visual page builder and CMS for Shopify Hydrogen. Developers build a theme once with React components; merchants then edit content, layout, and styling visually — like the Shopify theme editor, but for Hydrogen. See [Why Weaverse for Hydrogen](/intro/why-weaverse-for-hydrogen).
+- **Weaverse Studio** — The visual editor at `studio.weaverse.io`, where you arrange sections, edit content, and preview changes live. See [Studio Interface Tour](/studio-guide/interface-tour).
+- **Shopify Hydrogen** — Shopify's React framework for building custom (headless) storefronts. Weaverse themes are Hydrogen apps. See [How Weaverse Works](/intro/how-it-works).
+- **Shopify Oxygen** — Shopify's global edge hosting platform for deploying Hydrogen storefronts. See [Deploy to Oxygen](/guides/deployment/oxygen).
+- **Project** — A Weaverse project connects a Hydrogen storefront to Studio; its `WEAVERSE_PROJECT_ID` ties your local code to the editor. See [Project Structure](/intro/project-structure).
+- **Storefront API** — Shopify's GraphQL API for reading store data (products, collections, cart). Weaverse components query it through the Weaverse client. See [Section Data Fetching](/development-guide/data-fetching).
+
+## Themes, Pages & Structure
+
+- **Theme** — A complete Hydrogen storefront that combines code structure with Weaverse's visual editing (for example Pilot or Naturelle). See [Themes & Templates](/hydrogen-themes).
+- **Pilot** — Weaverse's flagship reference theme: a fully featured Hydrogen storefront and the recommended starting point. See [Pilot Theme Overview](/hydrogen-themes/pilot-theme-overview).
+- **Section** — A page-level building block that merchants add, reorder, and configure in Studio. Sections are Weaverse components registered for the page. See [Pilot Theme Sections](/hydrogen-themes/pilot-theme-sections).
+- **Global Section** — A reusable section (such as a header or footer) saved once and shared across pages, so a single edit updates every instance. See [Global Sections](/features/global-sections).
+- **Template** — A reusable layout for a Shopify resource type (product, collection, page, blog) that overrides the default layout. See [Custom Templates](/features/custom-templates).
+- **Custom Page** — A brand-new route created in Weaverse, as opposed to a template that overrides an existing resource. See [Custom Pages](/features/custom-pages).
+- **Navigation Menu** — Storefront menus driven by Shopify's menu system and rendered through Weaverse. See [Navigation Menus](/features/navigation-menus).
+
+## Components & Schema
+
+- **Component** — A reusable React UI element with a Weaverse schema. The top-level components used on pages are called **sections**. See [Creating Components](/development-guide/creating-components).
+- **Schema** — The configuration object that registers a component with Weaverse, defining its `type`, `title`, editor `settings`, allowed `childTypes`, `presets`, and more. Created with `createSchema()`. See [Component Schema](/development-guide/component-schema).
+- **`createSchema()`** — The function from `@weaverse/hydrogen` used to define a component's schema. See [Component Schema](/development-guide/component-schema).
+- **Settings** — The grouped editor inputs that make a component configurable by merchants. (Formerly *inspector*, now deprecated.) See [Input Settings](/development-guide/input-settings).
+- **Input** — A single configurable field within a component's settings: text, image, range, color, select, and so on. See [Input Settings](/development-guide/input-settings).
+- **Child Component / `childTypes`** — Components allowed to nest inside another (for example slides inside a slideshow), declared via `childTypes` in the schema. See [Component Schema](/development-guide/component-schema).
+- **Presets** — Default content and settings applied when a component is first added to a page. See [Component Schema](/development-guide/component-schema).
+
+## Data & Theme Settings
+
+- **Loader** — A component's server-side data-fetching function. Weaverse calls it with `ComponentLoaderArgs` so a section can fetch its own data. See [Section Data Fetching](/development-guide/data-fetching).
+- **Theme Settings** — Global, site-wide configuration (colors, fonts, layout) defined in the theme schema and editable in Studio. See [Styling & Theming](/development-guide/styling-theming).
+- **Theme Schema** — The `HydrogenThemeSchema` that declares all global theme settings for a storefront. See [Styling & Theming](/development-guide/styling-theming).
+- **Data Revalidation (`shouldRevalidate`)** — A flag on an input that tells Weaverse to re-run a component's loader when that setting changes, keeping displayed data in sync. See [Section Data Fetching](/development-guide/data-fetching).
+- **`fetchWithCache`** — A Weaverse utility for fetching external APIs with Hydrogen's caching applied. See [Section Data Fetching](/development-guide/data-fetching).
+- **Metaobjects** — Shopify's structured custom-content records, used by themes such as Pilot to model reusable content. See [Pilot Theme Overview](/hydrogen-themes/pilot-theme-overview).
+
+## SDK & API Reference
+
+- **`@weaverse/hydrogen`** — The Weaverse SDK for Hydrogen: components, hooks, schema helpers, and the client. See [Weaverse SDKs](/developer-tools/weaverse-sdks).
+- **WeaverseRoot** — The core component that renders Weaverse content (sections) from the Weaverse context. See [WeaverseRoot](/api-reference/weaverse-root).
+- **WeaverseClient** — The client that fetches Weaverse page and theme content for your routes. See [WeaverseClient](/api-reference/weaverse-client).
+- **`withWeaverse`** — A higher-order component that sets up the Weaverse provider and theme-settings context around your app. See [withWeaverse](/api-reference/with-weaverse).
+- **`useWeaverse`** — Hook to access the active Weaverse instance. See [useWeaverse](/api-reference/use-weaverse).
+- **`useThemeSettings`** — Hook to read global theme settings inside components. See [useThemeSettings](/api-reference/use-theme-settings).
+- **`useItemInstance` / `useParentInstance` / `useChildInstances`** — Hooks to access a component instance and traverse the component tree. See [useItemInstance](/api-reference/use-item-instance).
+- **`getSelectedProductOptions`** — Utility that resolves the selected variant options from the request for product rendering. See [getSelectedProductOptions](/api-reference/get-selected-product-options).
+- **Content API** — Weaverse's API for fetching project and page content outside the SDK. See [Content API Overview](/content-api/overview).
+- **Weaverse CLI** — The `@weaverse/cli` command-line tool for scaffolding and managing Weaverse Hydrogen projects. See [Weaverse CLI](/developer-tools/weaverse-cli).
+
+## Editor & Workflow
+
+- **Design Mode** — The state a storefront runs in when loaded inside Studio's iframe (detected via the `isDesignMode=true` query parameter), used to branch editor-only behavior. See [Studio vs. Live Environment](/development-guide/design-mode).
+- **Inspector** — Deprecated term for a component's **settings**. Use `settings` in schemas.
+- **Preview** — The live storefront rendered inside Studio. Local development serves it on `http://localhost:3456`. See [Quickstart](/intro/quickstart).
+- **Markets & Localization** — Weaverse's support for multiple languages and international markets. See [Markets & Localization](/features/markets-localization).
+
+---
+
+Can't find a term? Check the [FAQ](/resources/faq) or ask in our [community](/community/community).

--- a/resources/index.mdx
+++ b/resources/index.mdx
@@ -18,7 +18,7 @@ Complete 45-minute guide to building your first Weaverse Hydrogen store with mod
 ### [FAQ](resources/faq)
 Frequently asked questions, common issues, and debugging strategies.
 
-### Glossary
+### [Glossary](/resources/glossary)
 Definitions of Weaverse and Shopify Hydrogen terminology.
 
 ## Quick References


### PR DESCRIPTION
## What

Follow-up to #25 — turn the two de-linked items into real destinations.

### Glossary (new page)

- `resources/glossary.mdx` — ~35 Weaverse + Shopify Hydrogen terms grouped into **Platform & Core Concepts**, **Themes/Pages/Structure**, **Components & Schema**, **Data & Theme Settings**, **SDK & API Reference**, and **Editor & Workflow**. Every definition is grounded in the existing docs and links to the relevant guide.
- Registered in the **Help** nav group; the Glossary entry in `resources/index.mdx` is re-linked.

### Theme Marketplace — *not* recreated (it was deprecated)

Research showed the Weaverse Marketplace was retired:
- old docs now live under `weaverse/deprecated/` (`overview.md`, `submit-theme.md`)
- the builder's docs redirect map: `// Marketplace (no direct equivalent, redirect to themes)` and `marketplace/submit-theme → themes-templates/pilot-theme-overview`

So rather than fabricate a marketplace page, `hydrogen-themes/index.mdx` now points to the **live theme gallery** (`https://weaverse.io/themes`) and the **community** page for sharing themes.

## Verification

`mint broken-links` → **success, no broken links found** (validates the glossary's ~30 internal links, the re-linked glossary, and the gallery link).

If you'd prefer different wording/voice in the glossary, or want the gallery framed differently, easy to adjust.
