### PR TITLE
Document Content API page creation

### DIFF
--- a/content-api/create-page.mdx
+++ b/content-api/create-page.mdx
@@ -1,0 +1,134 @@
+---
+title: "Create Page"
+description: "Create a custom page through the Content API, optionally cloning an existing page layout"
+published: true
+---
+
+# Create Page
+
+```
+POST /api/v1/content/projects/:projectId/pages
+```
+
+Creates a new `CUSTOM` page in a project with a caller-supplied handle/path. The page starts blank unless you pass `basedOn`, which clones layout items from an existing page assigned to the same project.
+
+<Note>
+  Requires a Content API key. See [Authentication](/content-api/overview#authentication).
+</Note>
+
+## Path parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectId` | string | Yes | The project ID |
+
+## Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Must be `CUSTOM` |
+| `handle` | string | Yes | Custom page handle/path, for example `pages/gift-shop` or `about-us` |
+| `name` | string | No | Display name. Defaults to the normalized handle. |
+| `locale` | string | No | Assignment locale. Defaults to the global/default assignment (`""`). |
+| `basedOn` | string | No | Source page ID to clone layout items from. The source page must be assigned to the same project. |
+
+<Warning>
+  `POST /projects/:projectId/pages` also preserves the legacy POST-as-delete fallback. A body containing `pageIds` or `handles` is treated as a bulk-delete request. Use the create fields above for page creation.
+</Warning>
+
+## Example
+
+<Tabs>
+  <Tab title="cURL">
+    ```bash
+    curl -X POST \
+      -H "Authorization: Bearer YOUR_API_KEY" \
+      -H "Content-Type: application/json" \
+      "https://studio.weaverse.io/api/v1/content/projects/clx1abc23def456ghij/pages" \
+      -d '{
+        "type": "CUSTOM",
+        "name": "Gift Shop",
+        "handle": "pages/gift-shop"
+      }'
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    const res = await fetch(
+      `https://studio.weaverse.io/api/v1/content/projects/${projectId}/pages`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          type: 'CUSTOM',
+          name: 'Gift Shop',
+          handle: 'pages/gift-shop',
+        }),
+      },
+    )
+
+    const created = await res.json()
+    ```
+  </Tab>
+</Tabs>
+
+## Clone an existing layout
+
+Pass `basedOn` with a page ID from [List Pages](/content-api/list-pages) to clone the source page's layout items into the new page.
+
+```json
+{
+  "type": "CUSTOM",
+  "name": "Wholesale Landing Page",
+  "handle": "pages/wholesale",
+  "basedOn": "clz5wxy12abc345gift"
+}
+```
+
+The source page must be assigned to the same project. Cross-project source IDs return `404 PAGE_NOT_FOUND`.
+
+## Response
+
+```json
+{
+  "object": "page_create",
+  "page": {
+    "object": "page",
+    "id": "clz5wxy12abc345gift",
+    "type": "CUSTOM",
+    "handle": "pages/gift-shop",
+    "locale": "",
+    "items": [
+      {
+        "id": "019503a2-c4b6-7c9d-8e3f-1a2b3c4d5e6f",
+        "type": "root",
+        "data": {},
+        "children": null
+      }
+    ],
+    "updatedAt": "2026-07-09T10:30:00.000Z",
+    "meta": {
+      "inherited": false,
+      "sourceProjectId": "clx1abc23def456ghij",
+      "depth": 0
+    }
+  }
+}
+```
+
+The nested `page` object follows the same shape as [Get Page](/content-api/get-page).
+
+## Errors
+
+| Code | Status | When |
+|------|--------|------|
+| `UNAUTHORIZED` | 401 | Missing or invalid API key |
+| `FORBIDDEN` | 403 | API key does not have access to this project |
+| `PROJECT_NOT_FOUND` | 404 | Project does not exist or was deleted |
+| `PAGE_NOT_FOUND` | 404 | `basedOn` does not resolve to a live page in this project |
+| `CONFLICT` | 409 | A live page already exists for the same type, handle, and locale/market assignment |
+| `INVALID_PARAMS` | 400 | Invalid body, unsupported type, or missing/empty handle |
+| `INTERNAL_ERROR` | 500 | Unexpected server error |

--- a/content-api/overview.mdx
+++ b/content-api/overview.mdx
@@ -29,6 +29,7 @@ https://studio.weaverse.io/api/v1/content
 | `GET` | `/projects/:projectId` | Get a single project's metadata |
 | `PATCH` | `/projects/:projectId` | Update the project name |
 | `GET` | [`/projects/:projectId/pages`](/content-api/list-pages) | List page assignments |
+| `POST` | [`/projects/:projectId/pages`](/content-api/create-page) | Create a custom page |
 | `DELETE` | `/projects/:projectId/pages` | Bulk-delete pages (by ids or handles) |
 | `GET` | [`/projects/:projectId/pages/:type/:handle...`](/content-api/get-page) | Get page content |
 | `PATCH` | `/projects/:projectId/pages/:type/:handle...` | Update page content (merge item data, create items, relink children) |
@@ -48,6 +49,10 @@ in [`/openapi.json`](https://studio.weaverse.io/api/v1/content/openapi.json).
   `data` is shallow-merged over the item's existing data (send only changed
   top-level keys; nested objects are replaced wholesale). Unknown ids are
   created only when `type` is supplied. Max 100 items per request.
+- **Page create** — `POST .../pages` with
+  `{ "type": "CUSTOM", "handle", "name?", "locale?", "basedOn?" }`.
+  Creates a custom page with a blank root item, or clones layout items from
+  another page assigned to the same project when `basedOn` is supplied.
 - **Page delete** — `DELETE .../pages` with `{ "pageIds": [...] }` or
   `{ "handles": [...], "type", "locale?" }`. Soft-deletes up to 500 pages.
 - **Theme settings** — `PATCH .../theme-settings` with `{ "theme": { ... } }`.

--- a/docs.json
+++ b/docs.json
@@ -1,354 +1,346 @@
 {
-	"$schema": "https://mintlify.com/docs.json",
-	"theme": "mint",
-	"name": "Weaverse",
-	"colors": {
-		"primary": "#246aff",
-		"light": "#599aff",
-		"dark": "#1e40af"
-	},
-	"favicon": "/favicon.ico",
-	"integrations": {
-		"posthog": {
-			"apiKey": "phc_BnZAhY8ELZCZukEErb6ab9T7txSsMolcgGIIhMj5oSP",
-			"apiHost": "https://posthog.weaverse.io"
-		}
-	},
-	"navigation": {
-		"global": {
-			"anchors": [
-				{
-					"anchor": "Home",
-					"href": "https://weaverse.io",
-					"icon": "house"
-				},
-				{
-					"anchor": "Studio",
-					"href": "https://studio.weaverse.io/dashboard",
-					"icon": "paintbrush"
-				},
-				{
-					"anchor": "GitHub",
-					"href": "https://github.com/weaverse",
-					"icon": "github"
-				},
-				{
-					"anchor": "Community",
-					"href": "https://wvse.cc/weaverse-slack",
-					"icon": "slack"
-				}
-			]
-		},
-		"tabs": [
-			{
-				"tab": "Get Started",
-				"pages": [
-					{
-						"group": "Introduction",
-						"pages": [
-							"index",
-							"intro/why-weaverse-for-hydrogen",
-							"intro/how-it-works",
-							"intro/quickstart",
-							"intro/project-structure"
-						]
-					},
-					{
-						"group": "Studio Guide",
-						"pages": [
-							"studio-guide/interface-tour"
-						]
-					}
-				]
-			},
-			{
-				"tab": "Guides",
-				"pages": [
-					{
-						"group": "Environment",
-						"pages": [
-							"development-guide/environment-setup",
-							"development-guide/design-mode"
-						]
-					},
-					{
-						"group": "Building Components",
-						"pages": [
-							"development-guide/creating-components",
-							"development-guide/component-schema",
-							"development-guide/input-settings",
-							"development-guide/weaverse-component",
-							"development-guide/styling-theming",
-							"development-guide/data-fetching",
-							"development-guide/data-connectors"
-						]
-					},
-					{
-						"group": "Content Management",
-						"pages": [
-							"features/global-sections",
-							"features/navigation-menus",
-							"features/third-party-integrations",
-							"features/contact-form-klaviyo"
-						]
-					},
-					{
-						"group": "Internationalization",
-						"pages": [
-							"features/markets-localization",
-							"features/translation-feature-guide",
-							"features/i18next-integration"
-						]
-					},
-					{
-						"group": "Security & Privacy",
-						"pages": [
-							"features/content-security",
-							"features/cookie-consent-banner",
-							"features/analytics-tracking"
-						]
-					},
-					{
-						"group": "Pages & Routing",
-						"pages": [
-							"features/custom-pages",
-							"features/page-seo",
-							"features/custom-templates",
-							"features/custom-routing"
-						]
-					},
-					{
-						"group": "Advanced",
-						"pages": [
-							"guides/rendering-page",
-							"guides/localization-advanced",
-							"guides/multi-project-architecture",
-							"development-guide/customer-account-local-dev",
-							"development-guide/multipass-in-hydrogen"
-						]
-					},
-					{
-						"group": "Deployment",
-						"pages": [
-							"guides/deployment/index",
-							"guides/deployment/oxygen",
-							"guides/deployment/custom-domain-and-dns",
-							"guides/deployment/docker",
-							"guides/deployment/workers"
-						]
-					}
-				]
-			},
-			{
-				"tab": "API Reference",
-				"pages": [
-					{
-						"group": "Overview",
-						"pages": [
-							"api-reference/introduction"
-						]
-					},
-					{
-						"group": "Hooks",
-						"pages": [
-							"api-reference/use-weaverse",
-							"api-reference/use-item-instance",
-							"api-reference/use-parent-instance",
-							"api-reference/use-child-instances",
-							"api-reference/use-theme-settings"
-						]
-					},
-					{
-						"group": "Components",
-						"pages": [
-							"api-reference/weaverse-root",
-							"api-reference/weaverse-client",
-							"api-reference/with-weaverse"
-						]
-					},
-					{
-						"group": "Utilities & Types",
-						"pages": [
-							"api-reference/get-selected-product-options",
-							"api-reference/images-placeholders",
-							"api-reference/types"
-						]
-					},
-					{
-						"group": "Content API",
-						"pages": [
-							"content-api/overview",
-							"content-api/list-projects",
-							"content-api/list-pages",
-							"content-api/get-page",
-							"content-api/get-theme-settings",
-							"content-api/list-languages"
-						]
-					}
-				]
-			},
-			{
-				"tab": "Ecosystem",
-				"pages": [
-					{
-						"group": "Overview",
-						"pages": [
-							"ecosystem/index"
-						]
-					},
-					{
-						"group": "Developer Tools",
-						"pages": [
-							"developer-tools/weaverse-cli",
-							"developer-tools/weaverse-sdks",
-							"developer-tools/weaverse-mcp",
-							"developer-tools/shopify-hydrogen-skills"
-						]
-					},
-					{
-						"group": "APIs",
-						"pages": [
-							"features/api-access",
-							"features/admin-api-proxy"
-						]
-					},
-					{
-						"group": "Hydrogen Themes",
-						"pages": [
-							"hydrogen-themes/pilot-theme-overview",
-							"hydrogen-themes/pilot-theme-customization",
-							"hydrogen-themes/pilot-theme-sections"
-						]
-					},
-					{
-						"group": "Migration",
-						"pages": [
-							"migration-advanced/index",
-							"migration-advanced/v5-migration",
-							"migration-advanced/existing-hydrogen-integration"
-						]
-					}
-				]
-			},
-			{
-				"tab": "Help & Community",
-				"pages": [
-					{
-						"group": "Help",
-						"pages": [
-							"resources/faq",
-							"resources/tutorial",
-							"resources/example-components",
-							"resources/glossary"
-						]
-					},
-					{
-						"group": "Troubleshooting",
-						"pages": [
-							"troubleshooting/preview-errors",
-							"troubleshooting/component-not-selectable"
-						]
-					},
-					{
-						"group": "Community & Updates",
-						"pages": [
-							"community/community",
-							"changelog/index",
-							"changelog/weaverse-v5-release"
-						]
-					}
-				]
-			}
-		]
-	},
-	"logo": {
-		"light": "/logo/light.svg",
-		"dark": "/logo/dark.svg",
-		"href": "https://weaverse.io"
-	},
-	"navbar": {
-		"links": [],
-		"primary": {
-			"type": "button",
-			"label": "Studio",
-			"href": "https://studio.weaverse.io/dashboard"
-		}
-	},
-	"contextual": {
-		"options": [
-			"copy",
-			"view",
-			"chatgpt",
-			"claude",
-			"perplexity",
-			"mcp",
-			"cursor",
-			"vscode"
-		]
-	},
-	"redirects": [
-		{
-			"source": "/features/why-weaverse-for-hydrogen",
-			"destination": "/intro/why-weaverse-for-hydrogen"
-		},
-		{
-			"source": "/core-concepts/how-it-works",
-			"destination": "/intro/how-it-works"
-		},
-		{
-			"source": "/quickstart",
-			"destination": "/intro/quickstart"
-		},
-		{
-			"source": "/getting-started/quickstart",
-			"destination": "/intro/quickstart"
-		},
-		{
-			"source": "/core-concepts/project-structure",
-			"destination": "/intro/project-structure"
-		},
-		{
-			"source": "/deployment",
-			"destination": "/guides/deployment"
-		},
-		{
-			"source": "/oxygen-deployment",
-			"destination": "/guides/deployment/oxygen"
-		},
-		{
-			"source": "/custom-domain-and-dns-setup",
-			"destination": "/guides/deployment/custom-domain-and-dns"
-		},
-		{
-			"source": "/docker-deployment",
-			"destination": "/guides/deployment/docker"
-		},
-		{
-			"source": "/workers-deployment",
-			"destination": "/guides/deployment/workers"
-		},
-		{
-			"source": "/migration-advanced/custom-pages",
-			"destination": "/features/custom-pages"
-		},
-		{
-			"source": "/migration-advanced/custom-templates",
-			"destination": "/features/custom-templates"
-		},
-		{
-			"source": "/migration-advanced/custom-routing",
-			"destination": "/features/custom-routing"
-		},
-		{
-			"source": "/themes-templates/:slug*",
-			"destination": "/hydrogen-themes/:slug*"
-		}
-	],
-	"footer": {
-		"socials": {
-			"x": "https://x.com/WeaverseIO",
-			"github": "https://github.com/weaverse",
-			"slack": "https://wvse.cc/weaverse-slack"
-		}
-	}
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "Weaverse",
+  "colors": {
+    "primary": "#246aff",
+    "light": "#599aff",
+    "dark": "#1e40af"
+  },
+  "favicon": "/favicon.ico",
+  "integrations": {
+    "posthog": {
+      "apiKey": "phc_BnZAhY8ELZCZukEErb6ab9T7txSsMolcgGIIhMj5oSP",
+      "apiHost": "https://posthog.weaverse.io"
+    }
+  },
+  "navigation": {
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Home",
+          "href": "https://weaverse.io",
+          "icon": "house"
+        },
+        {
+          "anchor": "Studio",
+          "href": "https://studio.weaverse.io/dashboard",
+          "icon": "paintbrush"
+        },
+        {
+          "anchor": "GitHub",
+          "href": "https://github.com/weaverse",
+          "icon": "github"
+        },
+        {
+          "anchor": "Community",
+          "href": "https://wvse.cc/weaverse-slack",
+          "icon": "slack"
+        }
+      ]
+    },
+    "tabs": [
+      {
+        "tab": "Get Started",
+        "pages": [
+          {
+            "group": "Introduction",
+            "pages": [
+              "index",
+              "intro/why-weaverse-for-hydrogen",
+              "intro/how-it-works",
+              "intro/quickstart",
+              "intro/project-structure"
+            ]
+          },
+          {
+            "group": "Studio Guide",
+            "pages": ["studio-guide/interface-tour"]
+          }
+        ]
+      },
+      {
+        "tab": "Guides",
+        "pages": [
+          {
+            "group": "Environment",
+            "pages": [
+              "development-guide/environment-setup",
+              "development-guide/design-mode"
+            ]
+          },
+          {
+            "group": "Building Components",
+            "pages": [
+              "development-guide/creating-components",
+              "development-guide/component-schema",
+              "development-guide/input-settings",
+              "development-guide/weaverse-component",
+              "development-guide/styling-theming",
+              "development-guide/data-fetching",
+              "development-guide/data-connectors"
+            ]
+          },
+          {
+            "group": "Content Management",
+            "pages": [
+              "features/global-sections",
+              "features/navigation-menus",
+              "features/third-party-integrations",
+              "features/contact-form-klaviyo"
+            ]
+          },
+          {
+            "group": "Internationalization",
+            "pages": [
+              "features/markets-localization",
+              "features/translation-feature-guide",
+              "features/i18next-integration"
+            ]
+          },
+          {
+            "group": "Security & Privacy",
+            "pages": [
+              "features/content-security",
+              "features/cookie-consent-banner",
+              "features/analytics-tracking"
+            ]
+          },
+          {
+            "group": "Pages & Routing",
+            "pages": [
+              "features/custom-pages",
+              "features/page-seo",
+              "features/custom-templates",
+              "features/custom-routing"
+            ]
+          },
+          {
+            "group": "Advanced",
+            "pages": [
+              "guides/rendering-page",
+              "guides/localization-advanced",
+              "guides/multi-project-architecture",
+              "development-guide/customer-account-local-dev",
+              "development-guide/multipass-in-hydrogen"
+            ]
+          },
+          {
+            "group": "Deployment",
+            "pages": [
+              "guides/deployment/index",
+              "guides/deployment/oxygen",
+              "guides/deployment/custom-domain-and-dns",
+              "guides/deployment/docker",
+              "guides/deployment/workers"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "API Reference",
+        "pages": [
+          {
+            "group": "Overview",
+            "pages": ["api-reference/introduction"]
+          },
+          {
+            "group": "Hooks",
+            "pages": [
+              "api-reference/use-weaverse",
+              "api-reference/use-item-instance",
+              "api-reference/use-parent-instance",
+              "api-reference/use-child-instances",
+              "api-reference/use-theme-settings"
+            ]
+          },
+          {
+            "group": "Components",
+            "pages": [
+              "api-reference/weaverse-root",
+              "api-reference/weaverse-client",
+              "api-reference/with-weaverse"
+            ]
+          },
+          {
+            "group": "Utilities & Types",
+            "pages": [
+              "api-reference/get-selected-product-options",
+              "api-reference/images-placeholders",
+              "api-reference/types"
+            ]
+          },
+          {
+            "group": "Content API",
+            "pages": [
+              "content-api/overview",
+              "content-api/list-projects",
+              "content-api/list-pages",
+              "content-api/create-page",
+              "content-api/get-page",
+              "content-api/get-theme-settings",
+              "content-api/list-languages"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Ecosystem",
+        "pages": [
+          {
+            "group": "Overview",
+            "pages": ["ecosystem/index"]
+          },
+          {
+            "group": "Developer Tools",
+            "pages": [
+              "developer-tools/weaverse-cli",
+              "developer-tools/weaverse-sdks",
+              "developer-tools/weaverse-mcp",
+              "developer-tools/shopify-hydrogen-skills"
+            ]
+          },
+          {
+            "group": "APIs",
+            "pages": ["features/api-access", "features/admin-api-proxy"]
+          },
+          {
+            "group": "Hydrogen Themes",
+            "pages": [
+              "hydrogen-themes/pilot-theme-overview",
+              "hydrogen-themes/pilot-theme-customization",
+              "hydrogen-themes/pilot-theme-sections"
+            ]
+          },
+          {
+            "group": "Migration",
+            "pages": [
+              "migration-advanced/index",
+              "migration-advanced/v5-migration",
+              "migration-advanced/existing-hydrogen-integration"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Help & Community",
+        "pages": [
+          {
+            "group": "Help",
+            "pages": [
+              "resources/faq",
+              "resources/tutorial",
+              "resources/example-components",
+              "resources/glossary"
+            ]
+          },
+          {
+            "group": "Troubleshooting",
+            "pages": [
+              "troubleshooting/preview-errors",
+              "troubleshooting/component-not-selectable"
+            ]
+          },
+          {
+            "group": "Community & Updates",
+            "pages": [
+              "community/community",
+              "changelog/index",
+              "changelog/weaverse-v5-release"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "logo": {
+    "light": "/logo/light.svg",
+    "dark": "/logo/dark.svg",
+    "href": "https://weaverse.io"
+  },
+  "navbar": {
+    "links": [],
+    "primary": {
+      "type": "button",
+      "label": "Studio",
+      "href": "https://studio.weaverse.io/dashboard"
+    }
+  },
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
+  },
+  "redirects": [
+    {
+      "source": "/features/why-weaverse-for-hydrogen",
+      "destination": "/intro/why-weaverse-for-hydrogen"
+    },
+    {
+      "source": "/core-concepts/how-it-works",
+      "destination": "/intro/how-it-works"
+    },
+    {
+      "source": "/quickstart",
+      "destination": "/intro/quickstart"
+    },
+    {
+      "source": "/getting-started/quickstart",
+      "destination": "/intro/quickstart"
+    },
+    {
+      "source": "/core-concepts/project-structure",
+      "destination": "/intro/project-structure"
+    },
+    {
+      "source": "/deployment",
+      "destination": "/guides/deployment"
+    },
+    {
+      "source": "/oxygen-deployment",
+      "destination": "/guides/deployment/oxygen"
+    },
+    {
+      "source": "/custom-domain-and-dns-setup",
+      "destination": "/guides/deployment/custom-domain-and-dns"
+    },
+    {
+      "source": "/docker-deployment",
+      "destination": "/guides/deployment/docker"
+    },
+    {
+      "source": "/workers-deployment",
+      "destination": "/guides/deployment/workers"
+    },
+    {
+      "source": "/migration-advanced/custom-pages",
+      "destination": "/features/custom-pages"
+    },
+    {
+      "source": "/migration-advanced/custom-templates",
+      "destination": "/features/custom-templates"
+    },
+    {
+      "source": "/migration-advanced/custom-routing",
+      "destination": "/features/custom-routing"
+    },
+    {
+      "source": "/themes-templates/:slug*",
+      "destination": "/hydrogen-themes/:slug*"
+    }
+  ],
+  "footer": {
+    "socials": {
+      "x": "https://x.com/WeaverseIO",
+      "github": "https://github.com/weaverse",
+      "slack": "https://wvse.cc/weaverse-slack"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add Content API Create Page guide
- add Create Page to the Content API overview endpoint table
- register the new page in `docs.json`

Refs Weaverse/builder#2681
Related Weaverse/builder#2684

## Verification
- inspected changed docs files locally
- no local docs test/lint script exists in this repo root (`package.json` absent)