### PR TITLE
Content API: resource-backed template creation + shared-template assignments

### DIFF
--- a/content-api/assign-template-resources.mdx
+++ b/content-api/assign-template-resources.mdx
@@ -46,8 +46,8 @@ Per-assignment fields:
 
 - The target page's type is derived from its existing assignments and must be resource-backed.
 - A resource whose handle already points at **this** page is an idempotent no-op (returned under `existing`).
-- A resource whose handle already belongs to a **different** live page is **not** repointed — it is returned under `conflicts`.
-- New resources are created as assignment rows pointing at `pageId`.
+- **All-or-nothing.** Every requested handle is checked first. If any handle already belongs to a **different** live page, the whole request is rejected with `409 CONFLICT` (the clashing handles in `details.conflicts`) and **nothing is written** — a mixed batch never leaves partial assignments. A resource is **never** repointed away from another page.
+- New resources are created as assignment rows pointing at `pageId`, in a single transaction.
 - All lookups and writes are scoped strictly to `projectId`; the endpoint never touches another project's pages.
 
 ## Example
@@ -78,12 +78,11 @@ curl -X POST \
   ],
   "existing": [
     { "handle": "winter-drop", "locale": "", "assignmentId": "asg_0" }
-  ],
-  "conflicts": []
+  ]
 }
 ```
 
-Use the per-resource accounting to retry only the `conflicts` (e.g. after unassigning the handle from its current template).
+On a `409`, no assignment is created; inspect `details.conflicts`, unassign each clashing handle from its current template, then retry the batch.
 
 ## Errors
 
@@ -93,5 +92,6 @@ Use the per-resource accounting to retry only the `conflicts` (e.g. after unassi
 | `FORBIDDEN` | 403 | API key does not have access to this project |
 | `PROJECT_NOT_FOUND` | 404 | Project does not exist or was deleted |
 | `PAGE_NOT_FOUND` | 404 | The template page is not a live page in this project |
+| `CONFLICT` | 409 | A handle already belongs to a different live page (or a concurrent write won the race); nothing was assigned |
 | `INVALID_PARAMS` | 400 | Invalid body, empty/too many assignments, or the page cannot carry resource assignments |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |

--- a/content-api/assign-template-resources.mdx
+++ b/content-api/assign-template-resources.mdx
@@ -1,0 +1,97 @@
+---
+title: "Assign Template Resources"
+description: "Assign many Shopify resources to one shared template page (shared-template model), without creating page copies"
+published: true
+---
+
+# Assign Template Resources
+
+```
+POST /api/v1/content/projects/:projectId/template-assignments/:pageId
+```
+
+Assigns many Shopify resources to **one existing template page** — the shared-template model (one page, many assignments). Each resource becomes its own assignment row pointing at the same `pageId`, so the template's content stays **shared, not copied**.
+
+<Note>
+  Use this when many resources should share one template. To instead create an
+  independent, editable page copy per resource, use [Create Page](/content-api/create-page).
+</Note>
+
+<Note>
+  Requires a Content API key. See [Authentication](/content-api/overview#authentication).
+</Note>
+
+## Path parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectId` | string | Yes | The project ID |
+| `pageId` | string | Yes | The template page to assign resources to. Must be a live page assigned to this project and carry a resource-backed type (`PRODUCT`, `COLLECTION`, `PAGE`, `BLOG`, `ARTICLE`). |
+
+## Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `assignments` | array | Yes | 1–100 resources to assign. Each entry is `{ handle, shopifyResourceId?, locale? }`. |
+
+Per-assignment fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `handle` | string | Yes | Shopify resource handle (trimmed, kept verbatim). |
+| `shopifyResourceId` | string | No | Optional non-empty Shopify resource id (gid) bound to the assignment. |
+| `locale` | string | No | Assignment locale. Defaults to the global/default assignment (`""`). |
+
+## Behavior
+
+- The target page's type is derived from its existing assignments and must be resource-backed.
+- A resource whose handle already points at **this** page is an idempotent no-op (returned under `existing`).
+- A resource whose handle already belongs to a **different** live page is **not** repointed — it is returned under `conflicts`.
+- New resources are created as assignment rows pointing at `pageId`.
+- All lookups and writes are scoped strictly to `projectId`; the endpoint never touches another project's pages.
+
+## Example
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  "https://studio.weaverse.io/api/v1/content/projects/clx1abc23def456ghij/template-assignments/clz5wxy12abc345gift" \
+  -d '{
+    "assignments": [
+      { "handle": "summer-sale", "shopifyResourceId": "gid://shopify/Collection/123" },
+      { "handle": "winter-drop",  "shopifyResourceId": "gid://shopify/Collection/456" }
+    ]
+  }'
+```
+
+## Response
+
+```json
+{
+  "object": "template_assignments",
+  "pageId": "clz5wxy12abc345gift",
+  "type": "COLLECTION",
+  "requested": 2,
+  "created": [
+    { "handle": "summer-sale", "locale": "", "assignmentId": "asg_1" }
+  ],
+  "existing": [
+    { "handle": "winter-drop", "locale": "", "assignmentId": "asg_0" }
+  ],
+  "conflicts": []
+}
+```
+
+Use the per-resource accounting to retry only the `conflicts` (e.g. after unassigning the handle from its current template).
+
+## Errors
+
+| Code | Status | When |
+|------|--------|------|
+| `UNAUTHORIZED` | 401 | Missing or invalid API key |
+| `FORBIDDEN` | 403 | API key does not have access to this project |
+| `PROJECT_NOT_FOUND` | 404 | Project does not exist or was deleted |
+| `PAGE_NOT_FOUND` | 404 | The template page is not a live page in this project |
+| `INVALID_PARAMS` | 400 | Invalid body, empty/too many assignments, or the page cannot carry resource assignments |
+| `INTERNAL_ERROR` | 500 | Unexpected server error |

--- a/content-api/create-page.mdx
+++ b/content-api/create-page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Create Page"
-description: "Create a custom page or resource-backed override (e.g. COLLECTION) through the Content API, optionally cloning an existing layout"
+description: "Create a custom page or a resource-backed template override through the Content API, optionally cloning an existing layout"
 published: true
 ---
 
@@ -10,10 +10,16 @@ published: true
 POST /api/v1/content/projects/:projectId/pages
 ```
 
-Creates a page in a project. Two page types are creatable in v1:
+Creates a page in a project. Two kinds of page are creatable:
 
 - **`CUSTOM`** — a bespoke merchant page with a caller-supplied handle/path. Starts blank unless you pass `basedOn`.
-- **`COLLECTION`** — a resource-backed override / custom template for a specific collection PLP. Clones the project's shared default `COLLECTION` template (or the `basedOn` page) so the new page starts from a real layout.
+- **Resource-backed templates** (`PRODUCT`, `COLLECTION`, `PAGE`, `BLOG`, `ARTICLE`) — a per-resource override / custom template. Clones the project's shared default template for that type when one exists; otherwise starts blank. Pass `basedOn` to clone a specific page instead.
+
+<Note>
+  This endpoint creates **one new page per call** (a per-resource copy). To assign
+  many Shopify resources to a single shared template page without copying content,
+  use [Assign template resources](/content-api/assign-template-resources) instead.
+</Note>
 
 <Note>
   Requires a Content API key. See [Authentication](/content-api/overview#authentication).
@@ -29,12 +35,12 @@ Creates a page in a project. Two page types are creatable in v1:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | string | Yes | `CUSTOM` or `COLLECTION` |
-| `handle` | string | Yes | For `CUSTOM`, a page handle/path (e.g. `pages/gift-shop`). For `COLLECTION`, the Shopify collection handle (e.g. `summer-sale`). |
+| `type` | string | Yes | `CUSTOM`, `PRODUCT`, `COLLECTION`, `PAGE`, `BLOG`, or `ARTICLE` |
+| `handle` | string | Yes | For `CUSTOM`, a page handle/path (e.g. `pages/gift-shop`). For resource-backed types, the Shopify resource handle (e.g. `summer-sale`), kept verbatim. |
 | `name` | string | No | Display name. Defaults to the normalized handle. |
 | `locale` | string | No | Assignment locale. Defaults to the global/default assignment (`""`). |
-| `basedOn` | string | No | Source page ID to clone layout items from. The source page must be assigned to the same project. When omitted for `COLLECTION`, the shared default `COLLECTION` template is cloned. |
-| `shopifyResourceId` | string | No | Shopify resource id (gid) to bind to a `COLLECTION` override for the Studio assignment UX. Ignored for `CUSTOM`. |
+| `basedOn` | string | No | Source page ID to clone layout items from. The source page must be assigned to the same project. When omitted for a resource-backed type, the shared default template for that type is cloned **when one exists; otherwise the page starts blank**. |
+| `shopifyResourceId` | string | No | Optional non-empty Shopify resource id (gid). Validated when present; persisted for resource-backed types (`PRODUCT`/`COLLECTION`/`PAGE`/`BLOG`/`ARTICLE`); not stored for `CUSTOM`. |
 
 <Warning>
   `POST /projects/:projectId/pages` also preserves the legacy POST-as-delete fallback. A body containing `pageIds` or `handles` is treated as a bulk-delete request. Use the create fields above for page creation.
@@ -94,9 +100,9 @@ Pass `basedOn` with a page ID from [List Pages](/content-api/list-pages) to clon
 
 The source page must be assigned to the same project. Cross-project source IDs return `404 PAGE_NOT_FOUND`.
 
-## Create a COLLECTION override
+## Create a resource-backed override
 
-Create a per-collection override (custom template) so a specific collection PLP can carry editorial/content blocks. When you omit `basedOn`, the project's shared default `COLLECTION` template is cloned; pass `shopifyResourceId` to bind the Shopify collection for Studio's assignment UX.
+Create a per-resource override (custom template) so a specific resource page — for example a collection PLP — can carry editorial/content blocks. When you omit `basedOn`, the project's shared default template for that type is cloned **when one exists; otherwise the page starts with a blank root**. Pass `shopifyResourceId` to bind the Shopify resource for Studio's assignment UX.
 
 ```json
 {
@@ -107,7 +113,9 @@ Create a per-collection override (custom template) so a specific collection PLP 
 }
 ```
 
-If a live `COLLECTION` assignment already exists for the same handle and locale/market, the request returns `409 CONFLICT` and creates nothing. Use [Get Page](/content-api/get-page) and [Update Page](/content-api/get-page) to read or edit an existing override instead.
+This creates one page copy for the resource. If a live assignment already exists for the same type, handle, and locale/market, the request returns `409 CONFLICT` and creates nothing — read the existing page with [Get Page](/content-api/get-page) or edit its items with [Update Page](/content-api/update-page) instead.
+
+To point several resources at **one shared** template page rather than creating a copy per resource, see [Assign template resources](/content-api/assign-template-resources).
 
 ## Response
 
@@ -149,5 +157,5 @@ The nested `page` object follows the same shape as [Get Page](/content-api/get-p
 | `PROJECT_NOT_FOUND` | 404 | Project does not exist or was deleted |
 | `PAGE_NOT_FOUND` | 404 | `basedOn` does not resolve to a live page in this project |
 | `CONFLICT` | 409 | A live page already exists for the same type, handle, and locale/market assignment |
-| `INVALID_PARAMS` | 400 | Invalid body, unsupported type (only `CUSTOM` and `COLLECTION` are creatable), or missing/empty handle |
+| `INVALID_PARAMS` | 400 | Invalid body, unsupported type (creatable types are `CUSTOM`, `PRODUCT`, `COLLECTION`, `PAGE`, `BLOG`, `ARTICLE`), or missing/empty handle |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |

--- a/content-api/overview.mdx
+++ b/content-api/overview.mdx
@@ -29,10 +29,11 @@ https://studio.weaverse.io/api/v1/content
 | `GET` | `/projects/:projectId` | Get a single project's metadata |
 | `PATCH` | `/projects/:projectId` | Update the project name |
 | `GET` | [`/projects/:projectId/pages`](/content-api/list-pages) | List page assignments |
-| `POST` | [`/projects/:projectId/pages`](/content-api/create-page) | Create a page (`CUSTOM` or `COLLECTION` override) |
+| `POST` | [`/projects/:projectId/pages`](/content-api/create-page) | Create a page (`CUSTOM` or a resource-backed template override) |
+| `POST` | [`/projects/:projectId/template-assignments/:pageId`](/content-api/assign-template-resources) | Assign many resources to one shared template page |
 | `DELETE` | `/projects/:projectId/pages` | Bulk-delete pages (by ids or handles) |
 | `GET` | [`/projects/:projectId/pages/:type/:handle...`](/content-api/get-page) | Get page content |
-| `PATCH` | `/projects/:projectId/pages/:type/:handle...` | Update page content (merge item data, create items, relink children) |
+| `PATCH` | [`/projects/:projectId/pages/:type/:handle...`](/content-api/update-page) | Update page content (merge item data, create items, relink children) |
 | `GET` | [`/projects/:projectId/theme-settings`](/content-api/get-theme-settings) | Get theme settings |
 | `PATCH` | `/projects/:projectId/theme-settings` | Merge top-level theme settings keys |
 | `GET` | [`/projects/:projectId/languages`](/content-api/list-languages) | List configured locales |
@@ -50,11 +51,19 @@ in [`/openapi.json`](https://studio.weaverse.io/api/v1/content/openapi.json).
   top-level keys; nested objects are replaced wholesale). Unknown ids are
   created only when `type` is supplied. Max 100 items per request.
 - **Page create** — `POST .../pages` with
-  `{ "type": "CUSTOM" | "COLLECTION", "handle", "name?", "locale?", "basedOn?", "shopifyResourceId?" }`.
-  `CUSTOM` creates a bespoke page with a blank root item (or clones `basedOn`).
-  `COLLECTION` creates a resource-backed override that clones the project's
-  shared default `COLLECTION` template (or `basedOn`). A duplicate live
-  assignment returns `409` and mutates nothing.
+  `{ "type", "handle", "name?", "locale?", "basedOn?", "shopifyResourceId?" }`.
+  Creatable types are `CUSTOM`, `PRODUCT`, `COLLECTION`, `PAGE`, `BLOG`,
+  `ARTICLE`. `CUSTOM` creates a bespoke page with a blank root item (or clones
+  `basedOn`). A resource-backed type creates a per-resource override that clones
+  the project's shared default template for that type when one exists (otherwise
+  blank), or clones `basedOn`. **This creates one new page per call (a
+  per-resource copy).** A duplicate live assignment returns `409` and mutates
+  nothing.
+- **Assign template resources** — `POST .../template-assignments/:pageId` with
+  `{ "assignments": [{ "handle", "shopifyResourceId?", "locale?" }] }`. Assigns
+  many resources to **one shared** template page without creating page copies.
+  A handle already on this page is an idempotent no-op; a handle on a different
+  live page is returned as a conflict (never repointed).
 - **Page delete** — `DELETE .../pages` with `{ "pageIds": [...] }` or
   `{ "handles": [...], "type", "locale?" }`. Soft-deletes up to 500 pages.
 - **Theme settings** — `PATCH .../theme-settings` with `{ "theme": { ... } }`.

--- a/content-api/overview.mdx
+++ b/content-api/overview.mdx
@@ -62,8 +62,9 @@ in [`/openapi.json`](https://studio.weaverse.io/api/v1/content/openapi.json).
 - **Assign template resources** — `POST .../template-assignments/:pageId` with
   `{ "assignments": [{ "handle", "shopifyResourceId?", "locale?" }] }`. Assigns
   many resources to **one shared** template page without creating page copies.
-  A handle already on this page is an idempotent no-op; a handle on a different
-  live page is returned as a conflict (never repointed).
+  All-or-nothing: a handle already on this page is an idempotent no-op, but if
+  any handle belongs to a different live page the whole request returns `409`
+  and writes nothing (never repointed).
 - **Page delete** — `DELETE .../pages` with `{ "pageIds": [...] }` or
   `{ "handles": [...], "type", "locale?" }`. Soft-deletes up to 500 pages.
 - **Theme settings** — `PATCH .../theme-settings` with `{ "theme": { ... } }`.

--- a/content-api/update-page.mdx
+++ b/content-api/update-page.mdx
@@ -1,0 +1,66 @@
+---
+title: "Update Page"
+description: "Update component items on an existing page — merge data, create items, and relink children"
+published: true
+---
+
+# Update Page
+
+```
+PATCH /api/v1/content/projects/:projectId/pages/:type/:handle...
+```
+
+Updates component items on the page resolved for `type` / `handle` / `locale` (same locale fallback as [Get Page](/content-api/get-page)). Also accepts `POST` for clients/proxies that cannot send `PATCH` bodies.
+
+<Note>
+  Requires a Content API key. See [Authentication](/content-api/overview#authentication).
+</Note>
+
+## Path parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `projectId` | string | Yes | The project ID |
+| `type` | string | Yes | Page type (e.g. `PRODUCT`, `COLLECTION`, `CUSTOM`) |
+| `handle` | string | Yes | Page handle; may include `/`. Use the exact handle from [List Pages](/content-api/list-pages). |
+
+## Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `locale` | string | No | Same resolution as Get Page; defaults to the stored default locale. |
+| `items` | array | Yes | Up to 100 item patches. Each entry is `{ id, data, type?, children? }`. |
+
+Behavior:
+
+- `data` is **shallow-merged** into the item's existing data — send only the changed top-level keys; nested objects are replaced wholesale.
+- Unknown item ids are **created only when `type` is supplied**; otherwise they are returned as `notFound`.
+- Each `children` reference must point to an existing page item or a typed new item created in the same request.
+- A page inherited from a parent project returns `409` — edit it on the source project.
+
+On success the edit goes live through `api.weaverse.io` like a Studio save.
+
+## Example
+
+```bash
+curl -X PATCH \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  "https://studio.weaverse.io/api/v1/content/projects/clx1abc23def456ghij/pages/COLLECTION/summer-sale" \
+  -d '{
+    "items": [
+      { "id": "019503a2-c4b6-7c9d-8e3f-1a2b3c4d5e6f", "data": { "heading": "Summer Sale" } }
+    ]
+  }'
+```
+
+## Errors
+
+| Code | Status | When |
+|------|--------|------|
+| `UNAUTHORIZED` | 401 | Missing or invalid API key |
+| `FORBIDDEN` | 403 | API key does not have access to this project |
+| `PAGE_NOT_FOUND` | 404 | No live page resolves for the given type/handle/locale |
+| `CONFLICT` | 409 | The page is inherited from a parent project (edit it on the source project) |
+| `INVALID_PARAMS` | 400 | Invalid body, too many items, or a bad `children` reference |
+| `INTERNAL_ERROR` | 500 | Unexpected server error |

--- a/docs.json
+++ b/docs.json
@@ -55,7 +55,9 @@
           },
           {
             "group": "Studio Guide",
-            "pages": ["studio-guide/interface-tour"]
+            "pages": [
+              "studio-guide/interface-tour"
+            ]
           }
         ]
       },
@@ -142,7 +144,9 @@
         "pages": [
           {
             "group": "Overview",
-            "pages": ["api-reference/introduction"]
+            "pages": [
+              "api-reference/introduction"
+            ]
           },
           {
             "group": "Hooks",
@@ -177,7 +181,9 @@
               "content-api/list-projects",
               "content-api/list-pages",
               "content-api/create-page",
+              "content-api/assign-template-resources",
               "content-api/get-page",
+              "content-api/update-page",
               "content-api/get-theme-settings",
               "content-api/list-languages"
             ]
@@ -189,7 +195,9 @@
         "pages": [
           {
             "group": "Overview",
-            "pages": ["ecosystem/index"]
+            "pages": [
+              "ecosystem/index"
+            ]
           },
           {
             "group": "Developer Tools",
@@ -202,7 +210,10 @@
           },
           {
             "group": "APIs",
-            "pages": ["features/api-access", "features/admin-api-proxy"]
+            "pages": [
+              "features/api-access",
+              "features/admin-api-proxy"
+            ]
           },
           {
             "group": "Hydrogen Themes",


### PR DESCRIPTION
## Summary

Documents the Content API work in Weaverse/builder#2711 (continues #2708 after review).

- **`create-page.mdx`** — expand creatable types from `CUSTOM`/`COLLECTION` to the full resource-backed set (`PRODUCT`, `COLLECTION`, `PAGE`, `BLOG`, `ARTICLE`); clarify shared-default-template cloning with the **blank-root fallback** when no default exists; document `shopifyResourceId`; note that create makes **one page copy per call**.
- **`assign-template-resources.mdx`** (new) — `POST /projects/:projectId/template-assignments/:pageId`, the shared-template model (one page, many assignments, no copies): idempotent no-op / conflict accounting, ownership scope.
- **`update-page.mdx`** (new) — documents the existing `PATCH` item-merge semantics (previously linked from the endpoint table but had no page).
- **`overview.mdx`** — endpoint table + write-semantics bullets for both new flows; fixes the **Update Page** link (was pointing at Get Page).
- **`docs.json`** — nav entries for the two new pages.

Refs Weaverse/builder#2708, Weaverse/builder#2711.

## Verification
All four review fixes from the builder-side review are reflected. No docs test/lint script exists in this repo root (`package.json` absent); changes scoped to `content-api/*.mdx` + `docs.json` and validated as parseable JSON.