### PR TITLE
Use canonical translation hook in docs

### DIFF
--- a/features/i18next-integration.mdx
+++ b/features/i18next-integration.mdx
@@ -8,7 +8,7 @@ published: true
 
 This guide explains how to integrate **i18next** as the primary translation engine in your Weaverse Hydrogen project. 
 
-While Weaverse provides a built-in `useThemeText()` hook for simple `{ {variable} }` substitution, integrating `i18next` enables advanced localization features like **plurals**, **context-based formatting**, and **ordinals**—without breaking Weaverse's visual translation workflow!
+While Weaverse provides a built-in `useTranslation()` hook for simple `{ {variable} }` substitution, integrating `i18next` enables advanced localization features like **plurals**, **context-based formatting**, and **ordinals**—without breaking Weaverse's visual translation workflow!
 
 ## How It Works
 
@@ -25,7 +25,7 @@ By routing translations through `i18next` first and gracefully falling back to W
 
 ## Step 1: Install Dependencies
 
-You only need the core `i18next` package. React bindings (`react-i18next`) are fully optional unless you strictly prefer using them in your components over `useThemeText`.
+You only need the core `i18next` package. React bindings (`react-i18next`) are optional unless you prefer using its hook directly instead of `useTranslation` from `@weaverse/hydrogen`.
 
 ```bash
 npm install i18next
@@ -148,10 +148,10 @@ Your components don't need any updates. Standard keys simply fall back to Weaver
 
 **React Component Example:**
 ```tsx
-import { useThemeText } from "@weaverse/hydrogen";
+import { useTranslation } from "@weaverse/hydrogen";
 
 export function CartItemCount({ count }: { count: number }) {
-  const { t } = useThemeText();
+  const { t } = useTranslation();
   
   // Will output "1 item" or "3 items" depending on the count!
   return <span>{t('cart.itemCount', { count })}</span>;

--- a/features/translation-feature-guide.mdx
+++ b/features/translation-feature-guide.mdx
@@ -202,7 +202,7 @@ For large catalogs or external translation vendors, move translations in and out
 
 The feature applies translations in two different ways:
 
-1. **Theme content:** Stored as project translation keys. Use the `useThemeText` hook (below) in your frontend components so these strings render dynamically based on the active locale.
+1. **Theme content:** Stored as project translation keys. Use the `useTranslation` hook (below) in your frontend components so these strings render dynamically based on the active locale.
 2. **Page content:** Stored separately from the main page JSON. **Weaverse automatically applies these localized strings at runtime.** You don't need to add any code, hooks, or rendering logic to your Weaverse sections — Weaverse Hydrogen components automatically display the translated text when a non-default locale is requested.
 
 Your source content stays intact, while each supported language gets its own translation layer applied on top.
@@ -243,21 +243,21 @@ For the smoothest rollout, use this order:
 
 ## Rendering Translations in the Theme
 
-To use translated theme content in your components, use the `useThemeText` hook from `@weaverse/hydrogen`. It connects to your theme's static content and the localized strings managed in the Translation Manager.
+To use translated theme content in your components, use the `useTranslation` hook from `@weaverse/hydrogen`. It connects to your theme's static content and the localized strings managed in the Translation Manager.
 
 1. **Import the hook:**
 
 ```tsx
-import { useThemeText } from "@weaverse/hydrogen";
+import { useTranslation } from "@weaverse/hydrogen";
 ```
 
 2. **Use the `t` function to render localized strings:**
 
 ```tsx
-import { useThemeText } from "@weaverse/hydrogen";
+import { useTranslation } from "@weaverse/hydrogen";
 
 export function CartSummary() {
-  const { t } = useThemeText();
+  const { t } = useTranslation();
 
   return (
     <div>
@@ -282,7 +282,7 @@ export function CartSummary() {
 **React Component:**
 ```tsx
 export function ProductImage({ name }: { name: string }) {
-  const { t } = useThemeText();
+  const { t } = useTranslation();
 
   return <img alt={t("product.pictureOf", { name })} />;
 }
@@ -290,7 +290,7 @@ export function ProductImage({ name }: { name: string }) {
 
 ### Advanced: Pluralization with i18next
 
-By default, the `t` function from `useThemeText` only supports simple string substitution (e.g., `{{variable}}`). It does not natively support advanced formatting like plurals.
+By default, the `t` function from `useTranslation` only supports simple string substitution (e.g., `{{variable}}`). It does not natively support advanced formatting like plurals.
 
 If your application requires plural forms or other advanced i18n features, configure an `i18next` instance and pass it as a custom translation function to Weaverse using the `withWeaverse` wrapper. For full step-by-step instructions, read the dedicated [i18next Integration Guide](./i18next-integration).
 


### PR DESCRIPTION
Update the translation docs to use the canonical `useTranslation` API from `@weaverse/hydrogen`.

- Refresh the Translation Feature Guide examples and explanations.
- Update the optional i18next integration guide and clarify the hook source.

Validation: `mint validate`
