### PR TITLE
Document function-based component availability

### DIFF
--- a/api-reference/types.mdx
+++ b/api-reference/types.mdx
@@ -48,10 +48,12 @@ interface HydrogenComponentSchema {
   inspector?: InspectorGroup[]; // Deprecated: use 'settings' instead
   presets?: Omit<HydrogenComponentPresets, 'type'>;
   limit?: number;
+  /** @deprecated Use enabled instead. */
   enabledOn?: {
     pages?: ('*' | PageType)[];
     groups?: ('*' | 'header' | 'footer' | 'body')[];
   };
+  enabled?: Resolvable<boolean, ComponentAvailabilityContext>;
   pages?: ('*' | PageType)[];
   groups?: ('*' | 'header' | 'footer' | 'body')[];
 }
@@ -206,6 +208,48 @@ type PageType =
   | 'ARTICLE'
   | 'CUSTOM';
 ```
+
+### Component Availability
+
+The canonical availability types are exported by `@weaverse/schema`:
+
+```typescript
+import type {
+  ComponentAvailabilityContext,
+  ComponentGroup,
+  Resolvable,
+} from '@weaverse/schema';
+```
+
+Their definitions are:
+
+```typescript
+type ComponentGroup = 'body' | 'header' | 'footer';
+
+type ComponentAvailabilityContext = {
+  page: {
+    id: string;
+    type: PageType;
+    handle: string;
+    locale: string;
+  };
+  group: ComponentGroup;
+};
+
+type Resolvable<T, Context = unknown> =
+  | T
+  | ((context: Context) => T);
+```
+
+A component schema accepts either a static boolean or a synchronous callback:
+
+```typescript
+enabled?: Resolvable<boolean, ComponentAvailabilityContext>;
+```
+
+`enabledOn` is deprecated; move its page and group checks into `enabled`. Existing schemas remain supported, and Studio combines both properties using AND semantics when both are present. Callback errors, Promises, and non-boolean results make the component unavailable for new insertion, while existing instances remain editable. The callback runs in the storefront preview and is not serialized over Studio RPC.
+
+Studio currently evaluates component insertion for the `body` group. `header` and `footer` are reserved for placement surfaces that support them in the future.
 
 ### WeaverseI18n
 
@@ -386,10 +430,14 @@ export let schema = createSchema({
   settings?: InspectorGroup[];      // UI controls configuration
   childTypes?: string[];            // Allowed child component types
   limit?: number;                   // Maximum instances allowed
-  enabledOn?: {                     // Where component can be used
+  enabledOn?: {                     // Deprecated: use enabled
     pages?: PageType[];
     groups?: ('*' | 'header' | 'footer' | 'body')[];
   };
+  enabled?: Resolvable<             // Dynamic insertion availability
+    boolean,
+    ComponentAvailabilityContext
+  >;
   presets?: {                       // Default values and children
     children?: ComponentPresets[];
     [key: string]: any;
@@ -418,8 +466,9 @@ export let schema = createSchema({
       ],
     },
   ],
-  enabledOn: {
-    pages: ['INDEX', 'COLLECTION'],
-  },
+  enabled: ({ page, group }) =>
+    ['INDEX', 'COLLECTION'].includes(page.type) &&
+    group === 'body' &&
+    page.locale === 'en-us',
 });
 ```

--- a/development-guide/component-schema.mdx
+++ b/development-guide/component-schema.mdx
@@ -124,10 +124,12 @@ export let schema = createSchema({
   childTypes?: string[]
   presets?: Omit<HydrogenComponentPresets, 'type'>
   limit?: number
+  /** @deprecated Use enabled instead */
   enabledOn?: {
     pages?: ('*' | PageType)[]
     groups?: ('*' | 'header' | 'footer' | 'body')[]
   }
+  enabled?: boolean | ((context: ComponentAvailabilityContext) => boolean)
 });
 ```
 
@@ -375,7 +377,7 @@ export let schema = createSchema({
 });
 ```
 
-### `enabledOn`
+### `enabledOn` (deprecated)
 
 ```tsx
 enabledOn?: {
@@ -384,13 +386,32 @@ enabledOn?: {
 }
 ```
 
-The `enabledOn` property controls where components can be used within a theme.
+The `enabledOn` property controls where components can be used within a theme, but it is deprecated. Use `enabled` for both static and context-aware availability rules. Existing schemas remain supported, and when both properties are present both rules must pass.
 
 > **Note to users:** The `groups` feature for managing components in header/footer sections is not available yet. Currently, only the `pages` property is functional. The `groups` feature will be implemented in a future release.
 
 #### Page Types
 
 The `pages` array specifies which page types can include this component. Use `'*'` to allow the component on all page types.
+
+Migrate page and group checks directly into `enabled`:
+
+```tsx
+// Before
+export let schema = createSchema({
+  type: 'product-recommendations',
+  title: 'Product recommendations',
+  enabledOn: { pages: ['PRODUCT'], groups: ['body'] },
+});
+
+// After
+export let schema = createSchema({
+  type: 'product-recommendations',
+  title: 'Product recommendations',
+  enabled: ({ page, group }) =>
+    page.type === 'PRODUCT' && group === 'body',
+});
+```
 
 ```tsx
 type PageType =
@@ -404,6 +425,46 @@ type PageType =
   | 'ARTICLE'
   | 'CUSTOM'
 ```
+
+### `enabled`
+
+```tsx
+enabled?: boolean | ((context: ComponentAvailabilityContext) => boolean)
+```
+
+Use `enabled` to control whether a component can be inserted for the current page. A static boolean handles simple feature switches, while a synchronous callback can inspect the active page:
+
+```tsx
+export let schema = createSchema({
+  type: 'freebie-banner',
+  title: 'Freebie banner',
+  enabled: ({ page, group }) =>
+    group === 'body' &&
+    page.type === 'CUSTOM' &&
+    page.handle === 'freebies/essential',
+  settings: [],
+});
+```
+
+The callback receives:
+
+```tsx
+interface ComponentAvailabilityContext {
+  page: {
+    id: string
+    type: PageType
+    handle: string
+    locale: string
+  }
+  group: 'body' | 'header' | 'footer'
+}
+```
+
+`enabled` is combined with `enabledOn` using **AND semantics**. A component is available only when both rules allow it. The callback is evaluated synchronously in the storefront preview whenever Studio initializes or refreshes its page context; it is never sent over Studio RPC.
+
+Callbacks must be pure and return a boolean immediately. Returning a Promise or another value, or throwing an error, makes the component unavailable for new insertion without breaking Studio. Existing component instances remain visible and editable even when they are no longer available for insertion.
+
+> **Current placement support:** Studio currently evaluates insertion for the `body` group. The `header` and `footer` values are reserved for placement surfaces that support those groups in the future.
 
 ## Data Flow and Component Lifecycle
 

--- a/docs.json
+++ b/docs.json
@@ -90,7 +90,8 @@
               "features/global-sections",
               "features/navigation-menus",
               "features/third-party-integrations",
-              "features/contact-form-klaviyo"
+              "features/contact-form-klaviyo",
+              "features/mobile-app-pwa"
             ]
           },
           {

--- a/features/i18next-integration.mdx
+++ b/features/i18next-integration.mdx
@@ -8,7 +8,7 @@ published: true
 
 This guide explains how to integrate **i18next** as the primary translation engine in your Weaverse Hydrogen project. 
 
-While Weaverse provides a built-in `useThemeText()` hook for simple `{ {variable} }` substitution, integrating `i18next` enables advanced localization features like **plurals**, **context-based formatting**, and **ordinals**—without breaking Weaverse's visual translation workflow!
+While Weaverse provides a built-in `useTranslation()` hook for simple `{ {variable} }` substitution, integrating `i18next` enables advanced localization features like **plurals**, **context-based formatting**, and **ordinals**—without breaking Weaverse's visual translation workflow!
 
 ## How It Works
 
@@ -25,7 +25,7 @@ By routing translations through `i18next` first and gracefully falling back to W
 
 ## Step 1: Install Dependencies
 
-You only need the core `i18next` package. React bindings (`react-i18next`) are fully optional unless you strictly prefer using them in your components over `useThemeText`.
+You only need the core `i18next` package. React bindings (`react-i18next`) are optional unless you prefer using its hook directly instead of `useTranslation` from `@weaverse/hydrogen`.
 
 ```bash
 npm install i18next
@@ -148,10 +148,10 @@ Your components don't need any updates. Standard keys simply fall back to Weaver
 
 **React Component Example:**
 ```tsx
-import { useThemeText } from "@weaverse/hydrogen";
+import { useTranslation } from "@weaverse/hydrogen";
 
 export function CartItemCount({ count }: { count: number }) {
-  const { t } = useThemeText();
+  const { t } = useTranslation();
   
   // Will output "1 item" or "3 items" depending on the count!
   return <span>{t('cart.itemCount', { count })}</span>;

--- a/features/index.mdx
+++ b/features/index.mdx
@@ -21,6 +21,9 @@ Support multiple markets, currencies, and languages in your storefront.
 ### [Third-Party Integrations](features/third-party-integrations)
 Connect with external services, analytics, and marketing tools.
 
+### [Installable Mobile App (PWA)](features/mobile-app-pwa)
+Let shoppers install your storefront as a home-screen app on iOS and Android, branded from theme settings.
+
 ### [Content Security](features/content-security)
 Implement robust Content Security Policy (CSP) for enhanced security.
 

--- a/features/mobile-app-pwa.mdx
+++ b/features/mobile-app-pwa.mdx
@@ -1,0 +1,84 @@
+---
+title: Installable Mobile App (PWA)
+description: Turn your Weaverse Hydrogen storefront into an installable home-screen app on iOS and Android — no app store, no extra codebase, configured entirely from theme settings.
+published: true
+---
+
+# Installable Mobile App (PWA)
+
+Pilot can make your storefront installable as a **home-screen app** on both iOS and Android. Shoppers tap your icon and the store opens fullscreen — no browser bars, no app store review, no separate mobile codebase. Everything is configured from theme settings and branded per store.
+
+<Note>
+  Available in Pilot from version 2026.7+. The feature is **off by default** — enabling it is always an explicit choice.
+</Note>
+
+## For Merchants
+
+### Enable the app
+
+1. Open your project in **Weaverse Studio**.
+2. Go to **Theme settings → Mobile app (PWA)**.
+3. Turn on **Enable installable app**.
+4. Fill in the settings:
+
+| Setting | What it does |
+|---|---|
+| App name | The name under the icon on the home screen. Empty = your store name. |
+| Short name | Compact name (~12 characters) used where space is tight. |
+| App icon | Square PNG, at least 512×512. Empty = your Shopify brand logo — but a dedicated square icon looks much better. |
+| Theme color | Colors the status bar / window chrome of the installed app. |
+| Splash background | Background color of the launch screen. |
+| Show iOS install hint | One-time banner telling iPhone visitors how to install (recommended: on). |
+
+5. Publish. That's it.
+
+### How shoppers install it
+
+- **Android (Chrome):** Chrome automatically shows an **Install app** prompt (or menu → *Add to Home screen*). The store opens as a standalone fullscreen app afterward.
+- **iOS (Safari):** Apple never prompts on its own. Shoppers tap **Share → Add to Home Screen**. Because most people don't know this, Pilot shows a small one-time dismissible hint banner to iPhone visitors (you can turn it off).
+
+### What it is — and isn't
+
+- ✅ Real home-screen icon, fullscreen launch, your branding, instant updates on every deploy.
+- ✅ Checkout works exactly as before — nothing about carts, pricing, or checkout is ever cached or altered.
+- ❌ Not an App Store / Play Store listing (no review process — that's the point).
+- ❌ Push notifications are not part of this feature yet.
+
+## For Developers
+
+The implementation lives entirely in the Pilot theme — four pieces, all driven by the `Mobile app (PWA)` settings group:
+
+### Web app manifest — `app/routes/pwa/manifest.webmanifest.ts`
+
+A resource route (registered **top-level** in `app/routes.ts`, outside the `:locale?` prefix, like `robots.txt`). It reads `context.weaverse.loadThemeSettings()` plus a small shop query, and generates the manifest per merchant:
+
+- `name` / `short_name` fall back to the Shopify shop name
+- icons fall back to the Shopify brand logo; sizes (192/512/maskable) are produced with Shopify CDN params (`width`, `height`, `crop=center`)
+- returns **404 when the feature is disabled**, and caches for 1 hour
+
+### Head tags — `app/root.tsx`
+
+Rendered only when the feature is on: the manifest `<link>`, `theme-color`, `apple-touch-icon` (iOS ignores manifest icons), and standalone meta tags. The service worker registration is a nonce'd inline script; when the toggle is **off** it actively unregisters Pilot's worker — and only Pilot's, never third-party workers.
+
+### Service worker — `public/sw.js`
+
+Deliberately minimal and **whitelist-only**:
+
+- cache-first for hashed `/assets/*` build files (immutable)
+- stale-while-revalidate for `cdn.shopify.com` images, capped at 60 entries
+- **everything else — HTML documents, `/cart`, `/account`, `/api/*`, checkout — is never intercepted.** Pilot's SSR documents are intentionally anonymous so Oxygen can full-page cache them; the service worker preserves that design, so personalized or price-sensitive responses can never end up in a cache.
+- cache cleanup only touches `pilot-pwa-*` caches, so it can't break other software on the origin
+
+<Note>
+  If you customize `sw.js`, keep the whitelist approach. Adding HTML caching to an e-commerce storefront is how carts get stale and prices display wrong.
+</Note>
+
+### iOS install hint — `app/components/pwa-install-hint.tsx`
+
+A small client-only banner shown once to iOS Safari visitors (including modern iPadOS, which reports a Mac user agent). Dismissal persists in `localStorage`, with all storage access guarded so restricted browsing contexts can never break the layout.
+
+### Extending it
+
+- **Custom install UI on Android:** listen for `beforeinstallprompt` and call `prompt()` from your own button.
+- **Push notifications:** the service worker is the future mounting point, but pushes need a backend to store subscriptions and send messages — treat that as a platform feature, not a theme tweak.
+- The full design rationale lives in the Pilot repo at `.weaverse/docs/pwa-spec.md`.

--- a/features/translation-feature-guide.mdx
+++ b/features/translation-feature-guide.mdx
@@ -202,7 +202,7 @@ For large catalogs or external translation vendors, move translations in and out
 
 The feature applies translations in two different ways:
 
-1. **Theme content:** Stored as project translation keys. Use the `useThemeText` hook (below) in your frontend components so these strings render dynamically based on the active locale.
+1. **Theme content:** Stored as project translation keys. Use the `useTranslation` hook (below) in your frontend components so these strings render dynamically based on the active locale.
 2. **Page content:** Stored separately from the main page JSON. **Weaverse automatically applies these localized strings at runtime.** You don't need to add any code, hooks, or rendering logic to your Weaverse sections — Weaverse Hydrogen components automatically display the translated text when a non-default locale is requested.
 
 Your source content stays intact, while each supported language gets its own translation layer applied on top.
@@ -243,21 +243,21 @@ For the smoothest rollout, use this order:
 
 ## Rendering Translations in the Theme
 
-To use translated theme content in your components, use the `useThemeText` hook from `@weaverse/hydrogen`. It connects to your theme's static content and the localized strings managed in the Translation Manager.
+To use translated theme content in your components, use the `useTranslation` hook from `@weaverse/hydrogen`. It connects to your theme's static content and the localized strings managed in the Translation Manager.
 
 1. **Import the hook:**
 
 ```tsx
-import { useThemeText } from "@weaverse/hydrogen";
+import { useTranslation } from "@weaverse/hydrogen";
 ```
 
 2. **Use the `t` function to render localized strings:**
 
 ```tsx
-import { useThemeText } from "@weaverse/hydrogen";
+import { useTranslation } from "@weaverse/hydrogen";
 
 export function CartSummary() {
-  const { t } = useThemeText();
+  const { t } = useTranslation();
 
   return (
     <div>
@@ -282,7 +282,7 @@ export function CartSummary() {
 **React Component:**
 ```tsx
 export function ProductImage({ name }: { name: string }) {
-  const { t } = useThemeText();
+  const { t } = useTranslation();
 
   return <img alt={t("product.pictureOf", { name })} />;
 }
@@ -290,7 +290,7 @@ export function ProductImage({ name }: { name: string }) {
 
 ### Advanced: Pluralization with i18next
 
-By default, the `t` function from `useThemeText` only supports simple string substitution (e.g., `{{variable}}`). It does not natively support advanced formatting like plurals.
+By default, the `t` function from `useTranslation` only supports simple string substitution (e.g., `{{variable}}`). It does not natively support advanced formatting like plurals.
 
 If your application requires plural forms or other advanced i18n features, configure an `i18next` instance and pass it as a custom translation function to Weaverse using the `withWeaverse` wrapper. For full step-by-step instructions, read the dedicated [i18next Integration Guide](./i18next-integration).
 


### PR DESCRIPTION
## Summary

- document the `enabled` schema property and callback context
- explain `enabledOn` AND semantics and fail-closed behavior
- clarify preview/RPC behavior and current body-only placement support

Documents Weaverse/builder#2736