### PR TITLE
Align API reference with Weaverse SDK v5.19.1

### DIFF
--- a/api-reference/get-selected-product-options.mdx
+++ b/api-reference/get-selected-product-options.mdx
@@ -1,12 +1,12 @@
 ---
 title: getSelectedProductOptions
-description: Utility function that extracts selected product options from URL search parameters for product variant selection.
+description: Parse selected Shopify product options from request query parameters.
 published: true
 ---
 
 # getSelectedProductOptions
 
-The `getSelectedProductOptions` utility extends [Shopify Hydrogen's utility of the same name](https://shopify.dev/docs/api/hydrogen/2025-01/utilities/getselectedproductoptions) to provide a cleaner implementation for Weaverse applications. It extracts customer-selected product options from URL search parameters, allowing you to fetch the correct product variant based on customer selections.
+`getSelectedProductOptions` delegates to Shopify Hydrogen's utility and removes Weaverse-only query parameters before returning product options.
 
 ## Import
 
@@ -17,78 +17,33 @@ import { getSelectedProductOptions } from '@weaverse/hydrogen'
 ## Type
 
 ```typescript
-function getSelectedProductOptions(request: Request): SelectedOptionInput[]
+function getSelectedProductOptions(
+  request: Request
+): SelectedOptionInput[]
 ```
 
-## Parameters
+## Filtering
 
-- `request: Request` - The incoming request object from a Remix/Hydrogen loader function
+The wrapper removes:
 
-## Returns
+- `isDesignMode`
+- Parameters whose names start with `weaverse`
 
-- `SelectedOptionInput[]` - An array of selected option objects with `name` and `value` properties that can be passed directly to Shopify's Storefront API
+All other parameter names are preserved exactly as they appear in the URL.
 
-## Implementation Details
+## Example
 
-Weaverse's implementation enhances Shopify's utility by filtering out internal parameters that should not be treated as product options:
+For this request:
+
+```text
+https://example.com/products/t-shirt?Color=Blue&Size=XL&isDesignMode=true
+```
 
 ```tsx
-export function getSelectedProductOptions(
-  request: Request,
-): SelectedOptionInput[] {
-  // First calls Shopify's implementation
-  let options = hydrogen_getSelectedProductOptions(request)
-  
-  // Then filters out Weaverse-specific parameters
-  return options.filter(
-    ({ name }) => name !== 'isDesignMode' && !name.startsWith('weaverse'),
-  )
-}
+const selectedOptions = getSelectedProductOptions(request)
 ```
 
-This ensures that Weaverse design mode parameters and other internal options don't interfere with product variant selection.
-
-## Common Use Pattern
-
-### In Product Page Loaders
-
-This utility is typically used in a product page's loader function to fetch the correct product variant based on URL parameters:
-
-```tsx
-import { getSelectedProductOptions } from "@weaverse/hydrogen";
-import type { LoaderFunctionArgs } from "@shopify/remix-oxygen";
-import type { ProductQuery } from "storefront-api.generated";
-
-export async function loader({ params, request, context }: LoaderFunctionArgs) {
-  const { productHandle: handle } = params;
-  const { storefront } = context;
-  
-  // Extract selected options from URL search params
-  const selectedOptions = getSelectedProductOptions(request);
-  
-  // Use selected options to fetch the correct product variant
-  const { product } = await storefront.query<ProductQuery>(PRODUCT_QUERY, {
-    variables: {
-      handle,
-      selectedOptions,
-      country: storefront.i18n.country,
-      language: storefront.i18n.language,
-    },
-  });
-  
-  // Rest of your loader logic...
-  return { product };
-}
-```
-
-## How It Works
-
-The function works in two steps:
-
-1. It first leverages Shopify Hydrogen's implementation to extract search parameters from the request URL and convert them to the `SelectedOptionInput` format
-2. It then filters the results to exclude any options named 'isDesignMode' or starting with 'weaverse', which are used internally by the Weaverse system
-
-For example, a URL like `/products/t-shirt?option[Color]=Blue&option[Size]=XL&isDesignMode=true` would result in:
+The result is:
 
 ```json
 [
@@ -97,16 +52,43 @@ For example, a URL like `/products/t-shirt?option[Color]=Blue&option[Size]=XL&is
 ]
 ```
 
-Note that the `isDesignMode` parameter has been automatically filtered out.
+If the URL uses bracketed parameter names, those names remain bracketed:
 
-## When To Use
+```text
+?option[Color]=Blue&option[Size]=XL
+```
 
-- When implementing product pages with variant selection
-- When you need to fetch specific product variants based on URL parameters
-- In Hydrogen loaders that require selected product options for Storefront API queries
+```json
+[
+  { "name": "option[Color]", "value": "Blue" },
+  { "name": "option[Size]", "value": "XL" }
+]
+```
+
+## Loader Usage
+
+```tsx
+import { getSelectedProductOptions } from '@weaverse/hydrogen'
+import type { LoaderFunctionArgs } from '@shopify/remix-oxygen'
+
+export async function loader({
+  request,
+  context,
+  params,
+}: LoaderFunctionArgs) {
+  const selectedOptions = getSelectedProductOptions(request)
+
+  const { product } = await context.storefront.query(PRODUCT_QUERY, {
+    variables: {
+      handle: params.handle,
+      selectedOptions,
+    },
+  })
+
+  return { product }
+}
+```
 
 ## Related
 
-- [Shopify Hydrogen's getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/2025-01/utilities/getselectedproductoptions) - Original implementation that this function extends
-- [Shopify's Storefront API Product Variants](https://shopify.dev/docs/api/storefront/latest/objects/productvariant)
-- [WeaverseHydrogenRoot](/api-reference/weaverse-root) - For rendering product content with the selected variant
+- [Shopify Hydrogen `getSelectedProductOptions`](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions)

--- a/api-reference/images-placeholders.mdx
+++ b/api-reference/images-placeholders.mdx
@@ -18,7 +18,7 @@ import { IMAGES_PLACEHOLDERS } from '@weaverse/hydrogen'
 
 The current SDK exports these groups:
 
-- `logo_1` through `logo_3`
+- `logo_white` and `logo_black`
 - `image`
 - `banner_1` and `banner_2`
 - `collection_1` through `collection_6`

--- a/api-reference/images-placeholders.mdx
+++ b/api-reference/images-placeholders.mdx
@@ -1,12 +1,12 @@
 ---
 title: IMAGES_PLACEHOLDERS
-description: A collection of placeholder images for development in Weaverse Hydrogen themes.
+description: Placeholder image URLs exported by the Weaverse Hydrogen SDK.
 published: true
 ---
 
 # IMAGES_PLACEHOLDERS
 
-`IMAGES_PLACEHOLDERS` is a constant that provides a collection of placeholder image URLs for use during development in your Weaverse Hydrogen theme. These placeholders are useful for prototyping, default values, and testing before you have real content available.
+`IMAGES_PLACEHOLDERS` contains hosted placeholder image URLs for component presets and development.
 
 ## Import
 
@@ -14,111 +14,52 @@ published: true
 import { IMAGES_PLACEHOLDERS } from '@weaverse/hydrogen'
 ```
 
-## Structure
+## Available Keys
 
-`IMAGES_PLACEHOLDERS` is an object with predefined keys for common image use cases in e-commerce themes:
+The current SDK exports these groups:
 
-```typescript
-const IMAGES_PLACEHOLDERS = {
-  logo_white: string;
-  logo_black: string;
-  image: string;
-  banner_1: string;
-  banner_2: string;
-  collection_1: string;
-  collection_2: string;
-  collection_3: string;
-  collection_4: string;
-  collection_5: string;
-  collection_6: string;
-  product_1: string;
-  product_2: string;
-  // ... more product placeholders (up to product_18)
-}
-```
+- `logo_1` through `logo_3`
+- `image`
+- `banner_1` and `banner_2`
+- `collection_1` through `collection_6`
+- `product_1` through `product_18`
 
 ## Usage
 
-### As default values in a component schema
-
 ```tsx
-import { createSchema, IMAGES_PLACEHOLDERS } from '@weaverse/hydrogen';
+import {
+  createSchema,
+  IMAGES_PLACEHOLDERS,
+} from '@weaverse/hydrogen'
 
-export let schema = createSchema({
-  type: 'hero-section',
-  title: 'Hero Section',
+export const schema = createSchema({
+  type: 'hero-banner',
+  title: 'Hero Banner',
   settings: [
     {
-      group: 'Image',
+      group: 'Content',
       inputs: [
         {
           type: 'image',
-          name: 'backgroundImage',
-          label: 'Background Image',
-          defaultValue: IMAGES_PLACEHOLDERS.hero_1,
+          name: 'image',
+          label: 'Image',
+          defaultValue: IMAGES_PLACEHOLDERS.banner_1,
         },
       ],
     },
   ],
-});
+})
 ```
 
-### In a component for fallback images
-
 ```tsx
-import { IMAGES_PLACEHOLDERS } from '@weaverse/hydrogen'
-
-export function ProductCard({ data }) {
-  const { image = IMAGES_PLACEHOLDERS.product_1 } = data
-  
+export function ProductPlaceholder() {
   return (
-    <div className="product-card">
-      <img src={image} alt="Product" />
-      {/* ... rest of component */}
-    </div>
+    <img
+      src={IMAGES_PLACEHOLDERS.product_1}
+      alt="Placeholder product"
+    />
   )
 }
 ```
 
-### For populating demo data
-
-```tsx
-import { IMAGES_PLACEHOLDERS } from '@weaverse/hydrogen'
-
-export function createDemoProducts() {
-  return [
-    {
-      id: 'demo-1',
-      title: 'Demo Product 1',
-      image: IMAGES_PLACEHOLDERS.product_1,
-      price: 19.99,
-    },
-    {
-      id: 'demo-2',
-      title: 'Demo Product 2',
-      image: IMAGES_PLACEHOLDERS.product_2,
-      price: 29.99,
-    },
-    // More demo products
-  ]
-}
-```
-
-## Available Placeholders
-
-- **`logo_white`**: White version of a logo placeholder (600×200)
-- **`logo_black`**: Black version of a logo placeholder (600×200)
-- **`image`**: Generic image placeholder (1024×1024)
-- **`banner_1`**, **`banner_2`**: Banner/lifestyle image placeholders (1800×900)
-- **`collection_1`** through **`collection_6`**: Collection image placeholders for hats, shoes, glasses, lamps, bags, and watches (1024×1024)
-- **`product_1`** through **`product_18`**: Various product image placeholders for watches, bags, shoes, lamps, glasses, and hats (1024×1024)
-
-## Notes
-
-- All placeholders are served from Shopify CDN for reliable performance
-- The SVG placeholders are lightweight and load quickly
-- These placeholders should be replaced with real content in production
-
-## Related
-
-- [HydrogenComponentSchema](/api-reference/types) - Component schema type definition
+Use only exported keys. Accessing an unknown key such as `hero_1` returns `undefined` at runtime.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,79 +1,77 @@
 ---
-title: 'Introduction'
-description: 'Complete API reference for Weaverse Hydrogen development'
+title: Introduction
+sidebarTitle: Overview
+published: true
+description: Learn about the Weaverse SDK API reference for building Shopify Hydrogen storefronts.
 ---
 
 # API Reference
 
-This section provides comprehensive documentation for all Weaverse Hydrogen APIs, hooks, components, and utilities. Whether you're building custom components, integrating with Shopify, or extending Weaverse functionality, you'll find detailed information here.
+The Weaverse SDK provides the runtime, React bindings, Hydrogen integration, and schema utilities used to build Weaverse-powered storefronts.
 
-<Tip>
-  Looking for the **REST API** to access page content from external applications? See the [Content API](/content-api/overview) documentation.
-</Tip>
+## SDK Packages
 
-## Core Concepts
+### `@weaverse/hydrogen`
 
-Weaverse Hydrogen provides a powerful set of APIs for building visual, drag-and-drop storefronts. The API is organized around several key concepts:
+The primary package for Shopify Hydrogen applications. It includes:
 
-- **Components**: Reusable UI elements with visual configuration
-- **Hooks**: React hooks for accessing Weaverse state and functionality
-- **Utilities**: Helper functions for common tasks
-- **Types**: TypeScript interfaces and type definitions
+- `WeaverseClient` for server-side page and theme loading
+- `WeaverseHydrogenRoot` for page rendering
+- Hydrogen hooks, component types, and utilities
+- Re-exports from `@weaverse/react` and `@weaverse/schema`
 
-## Getting Started
+### `@weaverse/react`
 
-<CardGroup cols={2}>
-  <Card title="Components" icon="cube" href="/api-reference/weaverse-root">
-    Core rendering components for Weaverse content
-  </Card>
-  <Card title="Hooks" icon="atom" href="/api-reference/use-weaverse">
-    React hooks for accessing Weaverse functionality
-  </Card>
-  <Card title="Types" icon="code" href="/api-reference/types">
-    TypeScript interfaces and type definitions
-  </Card>
-  <Card title="Utilities" icon="wrench" href="/api-reference/get-selected-product-options">
-    Helper functions for common development tasks
-  </Card>
-</CardGroup>
+React bindings shared by framework integrations, including runtime contexts, hooks, and the lower-level `WeaverseRoot` renderer.
 
-## Package Structure
+### `@weaverse/core`
 
-Weaverse Hydrogen is distributed as multiple packages:
+Framework-independent runtime classes, item stores, events, and core data types.
 
-- **`@weaverse/hydrogen`** - Main package with components, hooks, and utilities
-- **`@weaverse/react`** - Core React rendering engine
-- **`@weaverse/core`** - Low-level Weaverse functionality
-- **`@weaverse/shopify`** - Shopify-specific components and integrations
+### `@weaverse/schema`
 
-## Import Patterns
+Schema definitions, Studio input types, availability types, and validation utilities.
+
+## Basic Usage
 
 ```tsx
-// Core hooks and components
-import { useWeaverse, WeaverseRoot } from '@weaverse/hydrogen'
+import {
+  WeaverseHydrogenRoot,
+  useWeaverse,
+  type WeaverseHydrogen,
+} from '@weaverse/hydrogen'
+import { components } from '~/weaverse/components'
 
-// Utilities
-import { getSelectedProductOptions, IMAGES_PLACEHOLDERS } from '@weaverse/hydrogen'
+export function WeaversePage() {
+  return <WeaverseHydrogenRoot components={components} />
+}
 
-// Types
-import type { HydrogenComponent, HydrogenComponentProps } from '@weaverse/hydrogen'
-```
+export function RuntimeInfo() {
+  const weaverse = useWeaverse<WeaverseHydrogen>()
 
-## TypeScript Support
-
-All APIs are fully typed with TypeScript. We recommend enabling strict mode in your `tsconfig.json`:
-
-```json
-{
-  "compilerOptions": {
-    "strict": true,
-    "noImplicitAny": true
-  }
+  return <span>{weaverse.data.name}</span>
 }
 ```
 
-## Need Help?
+## API Categories
 
-- **[Development Guide](/development-guide/index)** - Step-by-step development tutorials
-- **[Community](/community/community)** - Connect with other developers
-- **[FAQ](resources/faq)** - Common questions and solutions
+<CardGroup cols={2}>
+  <Card title="Hooks" icon="code" href="/api-reference/use-weaverse">
+    Access the Weaverse runtime, item stores, child instances, parent instances, and theme settings.
+  </Card>
+  <Card title="Components" icon="cube" href="/api-reference/weaverse-root">
+    Render Weaverse pages and initialize Hydrogen root providers.
+  </Card>
+  <Card title="Client" icon="server" href="/api-reference/weaverse-client">
+    Load page data, theme settings, and custom page metadata on the server.
+  </Card>
+  <Card title="Types and Utilities" icon="brackets-curly" href="/api-reference/types">
+    Reference public TypeScript contracts and helper functions.
+  </Card>
+</CardGroup>
+
+## Getting Help
+
+- [GitHub](https://github.com/Weaverse/weaverse)
+- [Community](https://community.weaverse.io)
+- [FAQ](/resources/faq)

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -73,5 +73,5 @@ export function RuntimeInfo() {
 ## Getting Help
 
 - [GitHub](https://github.com/Weaverse/weaverse)
-- [Community](https://community.weaverse.io)
+- [Community](/community/community)
 - [FAQ](/resources/faq)

--- a/api-reference/types.mdx
+++ b/api-reference/types.mdx
@@ -6,198 +6,209 @@ published: true
 
 # Types
 
-This document outlines the key TypeScript interfaces and types used in the Weaverse Hydrogen package. Understanding these types is essential for building type-safe components and integrating with the Weaverse system.
+This page summarizes the primary public types exported by `@weaverse/hydrogen` and `@weaverse/schema`.
 
 ## Component Types
 
-### HydrogenComponent
+### `HydrogenComponent`
 
-Defines a component module that can be registered with Weaverse.
+A component definition registered with Weaverse. The default export can be a forwarded-ref component or a function component.
 
 ```typescript
-interface HydrogenComponent<T extends HydrogenComponentProps = any> {
-  default: ForwardRefExoticComponent<T>;
-  schema: HydrogenComponentSchema;
-  loader?: (args: ComponentLoaderArgs) => Promise<unknown>;
+type HydrogenComponent<T extends HydrogenComponentProps = any> = {
+  default:
+    | ForwardRefExoticComponent<T>
+    | ((props: T) => React.JSX.Element)
+  schema: HydrogenComponentSchema
+  loader?: (args: ComponentLoaderArgs) => Promise<unknown>
 }
 ```
 
-### HydrogenComponentProps
-
-Base props for any Weaverse Hydrogen component.
+### `HydrogenComponentProps`
 
 ```typescript
 interface HydrogenComponentProps<L = any> extends WeaverseElement {
-  className?: string;
-  loaderData?: L;
-  children?: React.JSX.Element[];
+  children?: React.JSX.Element[]
+  className?: string
+  loaderData?: L
 }
 ```
 
-### HydrogenComponentSchema (Legacy)
+### `HydrogenComponentSchema`
 
-> **⚠️ Deprecated**: Use the `createSchema()` function instead of manually defining schema types. See the [Component Schema](#component-schema) section above for the modern approach.
-
-For legacy reference, the manual schema interface was:
+`HydrogenComponentSchema` is the current public alias for `SchemaType`. The type itself is not deprecated; only `inspector` and `enabledOn` are deprecated.
 
 ```typescript
-// Legacy approach - use createSchema() instead
-interface HydrogenComponentSchema {
-  childTypes?: string[];
-  settings: InspectorGroup[];
-  inspector?: InspectorGroup[]; // Deprecated: use 'settings' instead
-  presets?: Omit<HydrogenComponentPresets, 'type'>;
-  limit?: number;
-  /** @deprecated Use enabled instead. */
+type HydrogenComponentSchema = SchemaType
+
+interface SchemaType {
+  title: string
+  type: string
+  childTypes?: string[]
+  settings?: InspectorGroup[]
+  /** @deprecated Use settings. */
+  inspector?: InspectorGroup[]
+  presets?: {
+    children?: ComponentPresets[]
+    [key: string]: any
+  }
+  limit?: number
+  enabled?: Resolvable<boolean, ComponentAvailabilityContext>
+  /** @deprecated Use enabled. */
   enabledOn?: {
-    pages?: ('*' | PageType)[];
-    groups?: ('*' | 'header' | 'footer' | 'body')[];
-  };
-  enabled?: Resolvable<boolean, ComponentAvailabilityContext>;
-  pages?: ('*' | PageType)[];
-  groups?: ('*' | 'header' | 'footer' | 'body')[];
+    pages?: PageType[]
+    groups?: Array<'*' | ComponentGroup>
+  }
 }
 ```
 
-**Migration**: Replace manual schema definitions with `createSchema()`:
+Use `createSchema()` to preserve type inference and development-time validation:
 
 ```tsx
-// Old approach
-export const schema: HydrogenComponentSchema = { /* ... */ };
+import { createSchema } from '@weaverse/hydrogen'
 
-// New approach
-export let schema = createSchema({ /* ... */ });
+export const schema = createSchema({
+  type: 'hero-banner',
+  title: 'Hero Banner',
+  settings: [],
+})
 ```
 
-### HydrogenComponentData
+`createSchema()` lazy-loads Zod validation in development. Production builds return the schema without loading Zod; use the explicit validation APIs when production-time validation is required.
 
-Data structure for a component instance.
+### `HydrogenComponentData`
 
 ```typescript
-interface HydrogenComponentData {
-  data?: { [key: string]: any };
-  children?: { id: string }[];
-  id: string;
-  createdAt?: string;
-  updatedAt?: string;
-  deletedAt?: string;
+interface HydrogenComponentData extends ElementData {
+  id: string
+  type: string
+  children?: { id: string }[]
+  data?: Record<
+    string,
+    ComponentDataValue | Record<string, unknown>
+  >
+  createdAt?: string
+  updatedAt?: string
+  deletedAt?: string
 }
 ```
 
 ## Inspector Types
 
-Types used for defining the settings UI in Weaverse Studio.
+The public types retain “Inspector” in their names for compatibility, but new schemas should use the `settings` property.
 
-> **Note**: These types are still called "Inspector" types for historical reasons, but they are used to define the `settings` property in component schemas. The `inspector` property itself has been deprecated in favor of `settings`.
-
-### InspectorGroup
+### `InspectorGroup`
 
 ```typescript
 interface InspectorGroup {
-  group: string;
-  inputs: (BasicInput | HeadingInput)[];
+  group: string
+  inputs: (BasicInput | HeadingInput)[]
 }
 ```
 
-### BasicInput
+### `BasicInput`
 
 ```typescript
-type BasicInput = Omit<CoreBasicInput, 'condition'> & {
-  shouldRevalidate?: boolean;
-  condition?:
-    | string
-    | ((data: ElementData, weaverse: WeaverseHydrogen) => boolean);
-};
+interface BasicInput {
+  type: InputType
+  name: string
+  label?: string
+  placeholder?: string
+  helpText?: string
+  configs?: ConfigsProps
+  defaultValue?: unknown
+  shouldRevalidate?: boolean
+  sensitive?: boolean
+  condition?: string | Function
+}
 ```
 
-### HeadingInput
+String conditions remain supported but are deprecated; prefer a function.
+
+### `HeadingInput`
 
 ```typescript
-type HeadingInput = {
-  type: 'heading';
-  label: string;
-  [key: string]: any;
-};
+interface HeadingInput {
+  type: 'heading'
+  label: string
+  [key: string]: unknown
+}
 ```
 
 ## Loader Types
 
-Types related to data loading and server integration.
-
-### ComponentLoaderArgs
+### `ComponentLoaderArgs`
 
 ```typescript
-type ComponentLoaderArgs<T = any, E = any> = {
-  data: T;
-  weaverse: WeaverseClient;
-};
-```
-
-### RouteLoaderArgs
-
-```typescript
-interface RouteLoaderArgs extends RemixOxygenLoaderArgs {
-  context: AppLoadContext & {
-    weaverse: WeaverseClient;
-  };
+type ComponentLoaderArgs<T = any, _E = any> = {
+  data: T
+  weaverse: WeaverseClient
 }
 ```
 
-### WeaverseLoaderData
+### `RouteLoaderArgs`
 
 ```typescript
-interface WeaverseLoaderData {
+interface RouteLoaderArgs extends LoaderFunctionArgs {
+  context: WeaverseRouteAppLoadContext
+}
+```
+
+`WeaverseRouteAppLoadContext` includes the Hydrogen context and a `weaverse: WeaverseClient` property.
+
+### `WeaverseLoaderData`
+
+```typescript
+type WeaverseLoaderData = {
   configs: Omit<WeaverseProjectConfigs, 'publicEnv'> & {
-    requestInfo: WeaverseLoaderRequestInfo;
-  };
-  page: HydrogenPageData;
-  project: HydrogenProjectType;
-  pageAssignment: HydrogenPageAssignment;
+    requestInfo: WeaverseLoaderRequestInfo
+  }
+  page: HydrogenPageData
+  project: HydrogenProjectType
+  pageAssignment?: HydrogenPageAssignment
 }
 ```
 
 ## Theme Types
 
-### HydrogenThemeSettings
+### `HydrogenThemeSettings`
 
 ```typescript
 type HydrogenThemeSettings = {
-  [key: string]: any;
-};
-```
-
-### HydrogenThemeSchema
-
-```typescript
-interface HydrogenThemeSchema {
-  info: {
-    name: string;
-    version: string;
-    author: string;
-    authorProfilePhoto: string;
-    documentationUrl: string;
-    supportUrl: string;
-  };
-  settings: InspectorGroup[];
-  inspector?: InspectorGroup[]; // Deprecated: use 'settings' instead
-  i18n?: {
-    urlStructure: 'url-path' | 'subdomain' | 'top-level-domain';
-    defaultLocale: WeaverseI18n;
-    shopLocales: WeaverseI18n[];
-  };
+  [key: string]: any
 }
 ```
 
-> **Note**: The `inspector` property has been deprecated in favor of `settings`. While `inspector` is still supported for backward compatibility, new theme schemas should use `settings`.
+### `HydrogenThemeSchema`
 
-## Miscellaneous Types
+```typescript
+type HydrogenThemeSchema = {
+  info: {
+    name: string
+    version: string
+    author: string
+    authorProfilePhoto: string
+    documentationUrl: string
+    supportUrl: string
+  }
+  /** @deprecated Use settings. */
+  inspector?: InspectorGroup[]
+  settings?: InspectorGroup[]
+  i18n?: {
+    urlStructure: 'url-path' | 'subdomain' | 'top-level-domain'
+    defaultLocale: WeaverseI18n
+    shopLocales: WeaverseI18n[]
+    staticContent?: Record<string, unknown>
+    translation?: boolean
+  }
+}
+```
 
-### PageType
-
-Enumerates supported page types in Shopify Hydrogen.
+## Page Types
 
 ```typescript
 type PageType =
+  | '*'
   | 'INDEX'
   | 'PRODUCT'
   | 'ALL_PRODUCTS'
@@ -206,115 +217,95 @@ type PageType =
   | 'PAGE'
   | 'BLOG'
   | 'ARTICLE'
-  | 'CUSTOM';
+  | 'CUSTOM'
 ```
 
-### Component Availability
+## Component Availability
 
-The canonical availability types are exported by `@weaverse/schema`:
-
-```typescript
-import type {
-  ComponentAvailabilityContext,
-  ComponentGroup,
-  Resolvable,
-} from '@weaverse/schema';
-```
-
-Their definitions are:
+The canonical types are exported by `@weaverse/schema` and re-exported by `@weaverse/hydrogen`:
 
 ```typescript
-type ComponentGroup = 'body' | 'header' | 'footer';
-
-type ComponentAvailabilityContext = {
+interface ComponentAvailabilityContext {
+  group: 'body' | 'header' | 'footer'
   page: {
-    id: string;
-    type: PageType;
-    handle: string;
-    locale: string;
-  };
-  group: ComponentGroup;
-};
+    id: string
+    type: PageType
+    handle: string
+    locale: string
+  }
+}
 
-type Resolvable<T, Context = unknown> =
+type ComponentGroup = 'body' | 'header' | 'footer'
+
+type Resolvable<T, Context> =
   | T
-  | ((context: Context) => T);
+  | ((context: Context) => T)
 ```
 
-A component schema accepts either a static boolean or a synchronous callback:
+Use `enabled` for static or synchronous conditional availability:
 
 ```typescript
-enabled?: Resolvable<boolean, ComponentAvailabilityContext>;
+const schema = createSchema({
+  type: 'product-details',
+  title: 'Product details',
+  enabled: ({ page, group }) =>
+    page.type === 'PRODUCT' && group === 'body',
+})
 ```
 
-`enabledOn` is deprecated; move its page and group checks into `enabled`. Existing schemas remain supported, and Studio combines both properties using AND semantics when both are present. Callback errors, Promises, and non-boolean results make the component unavailable for new insertion, while existing instances remain editable. The callback runs in the storefront preview and is not serialized over Studio RPC.
+`enabledOn` remains supported for backward compatibility but is deprecated. Avoid relying on undocumented behavior for thrown errors, promises, RPC serialization, or existing instances; these semantics are not part of the public SDK contract.
 
-Studio currently evaluates component insertion for the `body` group. `header` and `footer` are reserved for placement surfaces that support them in the future.
-
-### WeaverseI18n
-
-Internationalization configuration.
+## Internationalization
 
 ```typescript
 type WeaverseI18n = I18nBase & {
-  label?: string;
-  pathPrefix?: string;
-  [key: string]: any;
-};
+  label?: string
+  pathPrefix?: string
+  [key: string]: any
+}
 ```
 
 ## Usage Example
 
-Here's how you might use these types to define a component:
-
 ```tsx
-import type {
-  HydrogenComponent,
-  HydrogenComponentProps,
-} from '@weaverse/hydrogen';
-import { createSchema } from '@weaverse/hydrogen';
+import {
+  createSchema,
+  type ComponentLoaderArgs,
+  type HydrogenComponent,
+  type HydrogenComponentProps,
+} from '@weaverse/hydrogen'
 
-type HeroBannerProps = HydrogenComponentProps<{
-  featuredProducts: any[];
-}> & {
-  heading: string;
-  subheading?: string;
-  backgroundImage?: string;
-  textColor?: string;
-};
+type Product = {
+  id: string
+  title: string
+}
+
+type HeroLoaderData = {
+  featuredProducts: Product[]
+}
+
+type HeroBannerProps = HydrogenComponentProps<HeroLoaderData> & {
+  heading: string
+  subheading?: string
+}
 
 function HeroBanner({
   heading,
   subheading,
-  backgroundImage,
-  textColor = '#ffffff',
   loaderData,
 }: HeroBannerProps) {
-  const { featuredProducts } = loaderData || {};
-  
   return (
-    <div 
-      className="hero-banner" 
-      style={{ 
-        backgroundImage: `url(${backgroundImage})`,
-        color: textColor,
-      }}
-    >
+    <section>
       <h1>{heading}</h1>
       {subheading && <p>{subheading}</p>}
-      
-      {featuredProducts?.length > 0 && (
-        <div className="featured-products">
-          {featuredProducts.map(product => (
-            <div key={product.id}>{product.title}</div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
+      {loaderData?.featuredProducts.map((product) => (
+        <div key={product.id}>{product.title}</div>
+      ))}
+    </section>
+  )
 }
 
-let schema = createSchema({
+const schema = createSchema({
   type: 'hero-banner',
   title: 'Hero Banner',
   settings: [
@@ -327,148 +318,53 @@ let schema = createSchema({
           label: 'Heading',
           defaultValue: 'Welcome to our store',
         },
-        {
-          type: 'text',
-          name: 'subheading',
-          label: 'Subheading',
-        },
-      ],
-    },
-    {
-      group: 'Styling',
-      inputs: [
-        {
-          type: 'image',
-          name: 'backgroundImage',
-          label: 'Background Image',
-        },
-        {
-          type: 'color',
-          name: 'textColor',
-          label: 'Text Color',
-          defaultValue: '#ffffff',
-        },
       ],
     },
   ],
-});
+})
 
-async function loader({ data, weaverse }) {
-  // Fetch featured products
-  const products = await weaverse.storefront.query('FEATURED_PRODUCTS_QUERY');
-  
+async function loader({
+  weaverse,
+}: ComponentLoaderArgs): Promise<HeroLoaderData> {
+  const { products } = await weaverse.storefront.query(
+    'FEATURED_PRODUCTS_QUERY'
+  )
+
   return {
-    featuredProducts: products?.data?.products?.nodes || [],
-  };
+    featuredProducts: products.nodes,
+  }
 }
 
-HeroBanner.defaultProps = {
-  heading: 'Welcome to our store',
-};
+const component: HydrogenComponent<HeroBannerProps> = {
+  default: HeroBanner,
+  schema,
+  loader,
+}
 
-export default HeroBanner;
-export { schema, loader };
+export default component
 ```
 
 ## Type Extensions
 
-Weaverse Hydrogen extends several types from Remix Oxygen and Shopify Hydrogen:
+A Hydrogen app can augment its load context and environment:
 
 ```typescript
-// Extend AppLoadContext with the weaverse client
 declare module '@shopify/remix-oxygen' {
-  export interface AppLoadContext {
-    weaverse: WeaverseClient;
+  interface AppLoadContext {
+    weaverse: WeaverseClient
   }
 }
 
-// Extend HydrogenEnv with Weaverse environment variables
 declare module '@shopify/hydrogen' {
   interface HydrogenEnv {
-    WEAVERSE_PROJECT_ID: string;
-    WEAVERSE_HOST: string;
-    WEAVERSE_API_KEY: string;
+    WEAVERSE_PROJECT_ID: string
+    WEAVERSE_HOST?: string
+    WEAVERSE_API_KEY: string
   }
 }
 ```
 
 ## Related
 
-- [WeaverseHydrogenRoot](/api-reference/weaverse-root) - The main component that uses these types
-- [WeaverseClient](/api-reference/weaverse-client) - Client for fetching Weaverse content
-
-### Component Schema
-
-The modern way to define component schemas is using the `createSchema()` function:
-
-```tsx
-import { createSchema } from '@weaverse/hydrogen';
-
-export let schema = createSchema({
-  type: 'my-component',
-  title: 'My Component',
-  settings: [
-    // ... settings configuration
-  ],
-});
-```
-
-The `createSchema()` function provides:
-- Runtime validation using Zod
-- Better TypeScript inference
-- Consistent validation across all schemas
-- Future-proof schema definitions
-
-### Schema Properties
-
-When using `createSchema()`, you can define the following properties:
-
-```tsx
-export let schema = createSchema({
-  title: string;                    // Display name in Weaverse Studio
-  type: string;                     // Unique component identifier
-  settings?: InspectorGroup[];      // UI controls configuration
-  childTypes?: string[];            // Allowed child component types
-  limit?: number;                   // Maximum instances allowed
-  enabledOn?: {                     // Deprecated: use enabled
-    pages?: PageType[];
-    groups?: ('*' | 'header' | 'footer' | 'body')[];
-  };
-  enabled?: Resolvable<             // Dynamic insertion availability
-    boolean,
-    ComponentAvailabilityContext
-  >;
-  presets?: {                       // Default values and children
-    children?: ComponentPresets[];
-    [key: string]: any;
-  };
-});
-```
-
-### Example Usage
-
-```tsx
-import { createSchema } from '@weaverse/hydrogen';
-
-export let schema = createSchema({
-  type: 'product-showcase',
-  title: 'Product Showcase',
-  settings: [
-    {
-      group: 'Content',
-      inputs: [
-        {
-          type: 'product',
-          name: 'product',
-          label: 'Featured Product',
-          shouldRevalidate: true,
-        },
-      ],
-    },
-  ],
-  enabled: ({ page, group }) =>
-    ['INDEX', 'COLLECTION'].includes(page.type) &&
-    group === 'body' &&
-    page.locale === 'en-us',
-});
-```
+- [WeaverseHydrogenRoot](/api-reference/weaverse-root) - Render Weaverse loader data
+- [WeaverseClient](/api-reference/weaverse-client) - Fetch Weaverse content

--- a/api-reference/use-child-instances.mdx
+++ b/api-reference/use-child-instances.mdx
@@ -6,7 +6,7 @@ published: true
 
 # useChildInstances
 
-The `useChildInstances` hook provides access to an array of all direct child component instances of a Weaverse component. This allows parent components to interact with, manipulate, or read data from their children.
+The `useChildInstances` hook returns the direct child item stores of a Weaverse component.
 
 ## Import
 
@@ -22,38 +22,40 @@ function useChildInstances(id?: string): WeaverseItemStore[]
 
 ## Parameters
 
-- `id?: string` - (Optional) The ID of the component whose children to retrieve. If not provided, uses the current component's ID.
+- `id?: string` — The parent component ID. When omitted, the hook uses the current component ID.
 
 ## Returns
 
-- `WeaverseItemStore[]` - An array of child component instances, or an empty array if no children exist
+- `WeaverseItemStore[]` — Child item stores that are present in the runtime registry. It returns an empty array when the parent instance cannot be found.
+
+<Warning>
+  The current SDK expects a found parent instance to contain a `children` array. If custom data omits that field, the hook can throw instead of returning an empty array.
+</Warning>
 
 ## Common Use Patterns
 
-### Coordinating Layout and Styles
-
-Parent components can coordinate layout and styling across all children:
+### Coordinating Child Layout
 
 ```tsx
-import { useChildInstances } from '@weaverse/hydrogen'
+import {
+  useChildInstances,
+  useThemeSettings,
+} from '@weaverse/hydrogen'
+import { useEffect } from 'react'
 
 export function ProductGrid() {
-  // Access configuration settings
   const { gridColumns, gapSize } = useThemeSettings()
-  
-  // Get all child instances
   const childInstances = useChildInstances()
-  
-  // Apply consistent layout rules to all children
+
   useEffect(() => {
-    childInstances.forEach(child => {
-      child.updateData({
+    for (const child of childInstances) {
+      child.setData({
         width: `calc(100% / ${gridColumns})`,
         margin: `${gapSize}px`,
       })
-    })
+    }
   }, [childInstances, gridColumns, gapSize])
-  
+
   return (
     <div className={`grid grid-cols-${gridColumns} gap-${gapSize}`}>
       {/* Child components rendered here by Weaverse */}
@@ -62,36 +64,34 @@ export function ProductGrid() {
 }
 ```
 
-### Managing Interactive Elements
-
-Parent components can manage interactive functionality across children, such as in carousel or tab implementations:
+### Managing Interactive Children
 
 ```tsx
-import { useChildInstances, useState } from '@weaverse/hydrogen'
+import { useChildInstances } from '@weaverse/hydrogen'
+import { useEffect, useState } from 'react'
 
 export function Carousel() {
   const [activeIndex, setActiveIndex] = useState(0)
   const slides = useChildInstances()
-  
-  // Set visibility state on slides based on active index
+
   useEffect(() => {
     slides.forEach((slide, index) => {
-      slide.updateData({
+      slide.setData({
         isVisible: index === activeIndex,
         zIndex: index === activeIndex ? 10 : 1,
       })
     })
   }, [slides, activeIndex])
-  
+
   return (
     <div className="carousel">
       <div className="carousel-container">
         {/* Slides rendered here by Weaverse */}
       </div>
       <div className="carousel-controls">
-        {slides.map((_, index) => (
-          <button 
-            key={index} 
+        {slides.map((slide, index) => (
+          <button
+            key={slide._id}
             onClick={() => setActiveIndex(index)}
             className={index === activeIndex ? 'active' : ''}
           >
@@ -106,35 +106,28 @@ export function Carousel() {
 
 ### Summarizing Child Data
 
-Parent components can collect and summarize data from child components:
-
 ```tsx
 import { useChildInstances } from '@weaverse/hydrogen'
+import { useMemo } from 'react'
 
 export function ReviewsSection() {
   const reviewItems = useChildInstances()
-  
-  // Calculate average rating from all review items
+
   const averageRating = useMemo(() => {
     if (reviewItems.length === 0) return 0
-    
+
     const total = reviewItems.reduce((sum, item) => {
       const { rating } = item.getSnapShot()
       return sum + (rating || 0)
     }, 0)
-    
+
     return total / reviewItems.length
   }, [reviewItems])
-  
+
   return (
-    <div className="reviews-section">
-      <div className="reviews-summary">
-        <h2>Customer Reviews</h2>
-        <div className="average-rating">{averageRating.toFixed(1)} / 5</div>
-      </div>
-      <div className="reviews-list">
-        {/* Review items rendered here by Weaverse */}
-      </div>
+    <div className="reviews-summary">
+      <h2>Customer Reviews</h2>
+      <div>{averageRating.toFixed(1)} / 5</div>
     </div>
   )
 }
@@ -142,37 +135,27 @@ export function ReviewsSection() {
 
 ## Implementation Details
 
-The `useChildInstances` hook:
-
-1. Calls `useItemInstance` to get the current component instance (or the instance with the provided ID)
-2. Accesses the children data from the component instance
-3. Maps through the children IDs to retrieve each child instance from the Weaverse registry
-4. Returns an array of child component instances
+The hook resolves the parent with `useItemInstance()`, maps its child IDs to `Weaverse.itemInstances`, and filters out IDs that do not have a registered item store:
 
 ```tsx
 export let useChildInstances = (id?: string) => {
   let currentInstance = useItemInstance(id)
-  if (!currentInstance) return []
+  if (!currentInstance) {
+    return []
+  }
   let { itemInstances } = Weaverse
-
   let {
     data: { children },
   } = currentInstance
-  return children.map(({ id }: { id: string }) => {
-    return itemInstances.get(id)
-  }) as WeaverseItemStore[]
+
+  return children
+    .map(({ id }: { id: string }) => itemInstances.get(id))
+    .filter(Boolean) as WeaverseItemStore[]
 }
 ```
-
-## When To Use
-
-- When parent components need to coordinate the behavior or appearance of their children
-- When implementing interactive components like carousels, tabs, or accordions
-- When collecting or summarizing data from multiple child components
-- When applying consistent styling or layout rules across child components
 
 ## Related
 
 - [useItemInstance](/api-reference/use-item-instance) - Access a specific component instance
 - [useParentInstance](/api-reference/use-parent-instance) - Access the parent component instance
-- [useWeaverse](/api-reference/use-weaverse) - Access the Weaverse instance
+- [useWeaverse](/api-reference/use-weaverse) - Access the Weaverse runtime

--- a/api-reference/use-item-instance.mdx
+++ b/api-reference/use-item-instance.mdx
@@ -1,12 +1,12 @@
 ---
 title: useItemInstance
-description: Hook for accessing specific component instances in Weaverse Hydrogen components.
+description: Hook for accessing component instances in Weaverse Hydrogen components.
 published: true
 ---
 
 # useItemInstance
 
-The `useItemInstance` hook allows you to access and interact with a specific component instance in the Weaverse component tree by its ID. This gives you direct access to the component's data and methods, allowing for advanced interactions and updates.
+The `useItemInstance` hook returns a component item store. Pass an instance ID to look up a specific component, or omit it to use the current component from `WeaverseItemContext`.
 
 ## Import
 
@@ -17,36 +17,33 @@ import { useItemInstance } from '@weaverse/hydrogen'
 ## Type
 
 ```typescript
-function useItemInstance(id: string): WeaverseItemStore | null
+function useItemInstance(id?: string): WeaverseItemStore | null
 ```
 
 ## Parameters
 
-- `id: string` - The unique identifier of the component instance to access
+- `id?: string` — The component instance ID. When omitted, the hook uses the current component ID.
 
 ## Returns
 
-- `WeaverseItemStore | null` - The component instance, or `null` if no component with the provided ID exists
+- `WeaverseItemStore | null` — The item store, or `null` when the instance cannot be found.
 
 ## Common Use Patterns
 
-### Directly Accessing Component Data
+### Accessing the Current Component
 
-Access and use a specific component's data anywhere in your application:
+Call the hook without an ID inside a rendered Weaverse component:
 
 ```tsx
 import { useItemInstance } from '@weaverse/hydrogen'
 
 export function ProductDetails() {
-  // Access a specific product showcase component by ID
-  const showcase = useItemInstance('product-showcase-123')
-  
-  if (!showcase) {
-    return <div>Showcase not found</div>
-  }
-  
-  const { product, selectedVariant, showPricing } = showcase.data
-  
+  const item = useItemInstance()
+
+  if (!item) return null
+
+  const { product, selectedVariant, showPricing } = item.data
+
   return (
     <div className="product-details">
       <h2>{product.title}</h2>
@@ -58,59 +55,30 @@ export function ProductDetails() {
 }
 ```
 
-### Finding the Closest Weaverse Component
-
-Use the hook to find the closest Weaverse component to a given element, which is useful for custom integrations:
-
-```tsx
-import { useItemInstance } from '@weaverse/hydrogen'
-import { useRef, useEffect, useState } from 'react'
-
-export function useClosestWeaverseItem(ref) {
-  const [weaverseId, setWeaverseId] = useState('')
-  const weaverseItem = useItemInstance(weaverseId)
-
-  useEffect(() => {
-    if (!weaverseItem && ref.current) {
-      const closest = ref.current.closest('[data-wv-id]')
-      if (closest) {
-        setWeaverseId(closest.getAttribute('data-wv-id'))
-      }
-    }
-  }, [ref])
-
-  return weaverseItem
-}
-```
-
-### Accessing and Updating Component State
-
-Use the hook to read and update component state:
+### Accessing a Specific Component
 
 ```tsx
 import { useItemInstance } from '@weaverse/hydrogen'
 
 export function ProductFilterControls() {
   const productGrid = useItemInstance('product-grid-main')
-  
+
   if (!productGrid) return null
-  
+
   const { filters, activeFilters } = productGrid.data
-  
-  const toggleFilter = (filterId) => {
-    const newActiveFilters = activeFilters.includes(filterId)
-      ? activeFilters.filter(id => id !== filterId)
+
+  const toggleFilter = (filterId: string) => {
+    const nextActiveFilters = activeFilters.includes(filterId)
+      ? activeFilters.filter((id: string) => id !== filterId)
       : [...activeFilters, filterId]
-      
-    productGrid.updateData({
-      activeFilters: newActiveFilters
-    })
+
+    productGrid.setData({ activeFilters: nextActiveFilters })
   }
-  
+
   return (
     <div className="filter-controls">
-      {filters.map(filter => (
-        <button 
+      {filters.map((filter) => (
+        <button
           key={filter.id}
           onClick={() => toggleFilter(filter.id)}
           className={activeFilters.includes(filter.id) ? 'active' : ''}
@@ -123,22 +91,41 @@ export function ProductFilterControls() {
 }
 ```
 
-## Implementation Details
+### Finding the Closest Weaverse Component
 
-The `useItemInstance` hook accesses the component registry in the Weaverse context to find and return the requested component instance. It returns `null` if no component with the provided ID exists.
+```tsx
+import { useItemInstance } from '@weaverse/hydrogen'
+import { useEffect, useState, type RefObject } from 'react'
+
+export function useClosestWeaverseItem(
+  ref: RefObject<HTMLElement | null>
+) {
+  const [weaverseId, setWeaverseId] = useState('')
+  const weaverseItem = useItemInstance(weaverseId)
+
+  useEffect(() => {
+    if (!weaverseItem && ref.current) {
+      const closest = ref.current.closest('[data-wv-id]')
+      setWeaverseId(closest?.getAttribute('data-wv-id') ?? '')
+    }
+  }, [ref, weaverseItem])
+
+  return weaverseItem
+}
+```
 
 ## Core Methods and Properties
 
 ### `data`
 
-- **Type**: `any`
-- **Description**: Contains all the component's data, including its props, state, and any custom data.
+- **Type**: `ElementData`
+- **Description**: The serialized component data. It always includes `id` and `type`, plus component-specific fields.
 
-### `updateData(newData)`
+### `setData(update)`
 
-- **Parameters**: `newData: Partial<ComponentData>`
-- **Returns**: `void`
-- **Description**: Updates the component's data and triggers a re-render.
+- **Parameters**: `Omit<ElementData, 'id' | 'type'>`
+- **Returns**: `ElementData`
+- **Description**: Merges the update into the item data and triggers a re-render.
 
 ### `triggerUpdate()`
 
@@ -148,22 +135,21 @@ The `useItemInstance` hook accesses the component registry in the Weaverse conte
 ### `_id`
 
 - **Type**: `string`
-- **Description**: The unique identifier of the component instance.
+- **Description**: The component instance ID.
 
 ### `_element`
 
 - **Type**: `HTMLElement | null`
-- **Description**: Reference to the component's DOM node, if available.
+- **Description**: The component's DOM node, when available.
 
 ## When To Use
 
-- When you need to access or manipulate a component that's not in the current component hierarchy
-- When implementing custom integrations that need to interact with specific Weaverse components
-- When building advanced features that require direct access to component instances
-- When implementing cross-component communication patterns
+- When a component needs its own runtime data or methods
+- When you need to interact with a component by instance ID
+- When implementing cross-component communication
 
 ## Related
 
 - [useParentInstance](/api-reference/use-parent-instance) - Access the parent component instance
 - [useChildInstances](/api-reference/use-child-instances) - Access child component instances
-- [useWeaverse](/api-reference/use-weaverse) - Access the Weaverse instance
+- [useWeaverse](/api-reference/use-weaverse) - Access the Weaverse runtime

--- a/api-reference/use-parent-instance.mdx
+++ b/api-reference/use-parent-instance.mdx
@@ -6,7 +6,7 @@ published: true
 
 # useParentInstance
 
-The `useParentInstance` hook allows a component to access its parent component's instance within the Weaverse component tree. This is useful for implementing child-parent communication patterns and accessing parent component data or methods.
+The `useParentInstance` hook looks up the current component's parent item store in the Weaverse runtime.
 
 ## Import
 
@@ -22,22 +22,25 @@ function useParentInstance(): WeaverseItemStore | null
 
 ## Returns
 
-- `WeaverseItemStore | null` - The parent component's instance, or `null` if no parent exists or can't be found
+- `WeaverseItemStore | null` — The parent item store, or `null` when the lookup does not find an instance.
+
+<Note>
+  In SDK v5.19.1, a missing parent ID falls back to the current item because `useParentInstance()` delegates to `useItemInstance(parentId || '')`. Root components therefore receive their own item store rather than `null`.
+</Note>
 
 ## Common Use Patterns
 
-### Accessing Loader Data
-
-The most common pattern is for child components to access loader data that was fetched by their parent component:
+### Accessing Parent Loader Data
 
 ```tsx
 import { useParentInstance } from '@weaverse/hydrogen'
 
 export function ProductItems() {
-  // Access the parent component's loader data
-  const parent = useParentInstance();
-  const { products } = parent.data.loaderData;
-  
+  const parent = useParentInstance()
+  const products = parent?.data.loaderData?.products
+
+  if (!products) return null
+
   return (
     <div className="product-grid">
       {products.nodes.map((product) => (
@@ -48,45 +51,18 @@ export function ProductItems() {
 }
 ```
 
-### Getting Product/Collection Data in Feature Sections
-
-Child components commonly use parent data to render products, collections, or other resources:
+### Reading Parent Configuration
 
 ```tsx
 import { useParentInstance } from '@weaverse/hydrogen'
 
-export function CollectionItems() {
-  const parent = useParentInstance();
-  const collections = parent.data.loaderData;
-  
-  if (!collections?.length) {
-    return <div>No collections available</div>;
-  }
-  
-  return (
-    <div className="collections-grid">
-      {collections.map((collection) => (
-        <CollectionCard 
-          key={collection.id} 
-          title={collection.title}
-          image={collection.image}
-          handle={collection.handle}
-        />
-      ))}
-    </div>
-  )
-}
-```
+export function ReviewItem() {
+  const parent = useParentInstance()
 
-### Accessing Configuration Settings
+  if (!parent) return null
 
-Children can access configuration settings from parent components to adapt their rendering:
+  const { showVerifiedBadge, verifiedBadgeText, showDate } = parent.data
 
-```tsx
-function ReviewItem() {
-  const parent = useParentInstance();
-  const { showVerifiedBadge, verifiedBadgeText, showDate, showCountry } = parent.data;
-  
   return (
     <div className="review-item">
       {/* Review content */}
@@ -99,36 +75,31 @@ function ReviewItem() {
 }
 ```
 
-### Fetching External Data
+### Fetching Data from Parent State
 
-Children can use parent data to determine what external data to fetch:
+Use React Router's `useFetcher` directly:
 
 ```tsx
-function JudgemeReview() {
-  const { useFetcher } = useRemixRuntime();
-  const { load, data: fetchData } = useFetcher();
-  const context = useParentInstance();
-  
-  // Get the product handle from the parent component
-  const handle = context?.data?.product?.handle;
-  const api = `/api/review/${handle}`;
-  
+import { useParentInstance } from '@weaverse/hydrogen'
+import { useEffect } from 'react'
+import { useFetcher } from 'react-router'
+
+export function JudgeMeReview() {
+  const { load, data } = useFetcher()
+  const parent = useParentInstance()
+  const handle = parent?.data.product?.handle
+
   useEffect(() => {
-    if (!handle) return;
-    load(api);
-  }, [handle, api, load]);
-  
-  // Render the reviews
+    if (handle) {
+      load(`/api/review/${handle}`)
+    }
+  }, [handle, load])
+
+  // Render the review data
 }
 ```
 
 ## Implementation Details
-
-The `useParentInstance` hook:
-
-1. Uses React's context API to access the current component's context, which includes the parent ID.
-2. Looks up the parent instance in the Weaverse component registry using the parent ID.
-3. Returns the parent component instance, which includes all its data and methods.
 
 ```tsx
 export let useParentInstance = () => {
@@ -137,15 +108,16 @@ export let useParentInstance = () => {
 }
 ```
 
+The empty-string fallback is significant because `useItemInstance()` treats a falsy ID as a request for the current item.
+
 ## When To Use
 
-- When a child component needs to access data or configuration from its parent.
-- When implementing coordinated behavior between parent and child components.
-- When you need to access loader data that was fetched at the parent level.
-- When a child component's rendering depends on parent component state or settings.
+- When a child component needs data or configuration from its parent
+- When implementing coordinated parent-child behavior
+- When a child's rendering depends on parent state
 
 ## Related
 
 - [useItemInstance](/api-reference/use-item-instance) - Access a specific component instance
 - [useChildInstances](/api-reference/use-child-instances) - Access child component instances
-- [useWeaverse](/api-reference/use-weaverse) - Access the Weaverse instance
+- [useWeaverse](/api-reference/use-weaverse) - Access the Weaverse runtime

--- a/api-reference/use-weaverse.mdx
+++ b/api-reference/use-weaverse.mdx
@@ -1,61 +1,60 @@
 ---
 title: useWeaverse
-description: Hook for accessing the global Weaverse instance in Weaverse Hydrogen components.
+description: Hook for accessing the active Weaverse runtime in Hydrogen components.
 published: true
 ---
 
 # useWeaverse
 
-The `useWeaverse` hook provides access to the global Weaverse instance, giving components access to page data, the component registry, and other essential Weaverse functionality. It serves as the main entry point for interacting with the Weaverse system.
+The `useWeaverse` hook returns the active Weaverse runtime. In Hydrogen themes, use the `WeaverseHydrogen` generic when you need Hydrogen-specific page data and runtime properties.
 
 ## Import
 
 ```tsx
-import { useWeaverse } from '@weaverse/hydrogen'
+import { useWeaverse, type WeaverseHydrogen } from '@weaverse/hydrogen'
 ```
 
 ## Type
 
 ```typescript
-function useWeaverse(): WeaverseInstance
+function useWeaverse<T = Weaverse>(): T
 ```
 
 ## Returns
 
-- `WeaverseInstance` - The Weaverse instance containing global state and methods
+- `T` — The active Weaverse runtime. It defaults to the core `Weaverse` type.
 
 ## Common Use Patterns
 
-### Accessing Component Registry
+### Accessing Component Instances
 
-Look up specific component instances from anywhere in your application:
+The `itemInstances` registry maps component instance IDs to their item stores:
 
 ```tsx
-import { useWeaverse } from '@weaverse/hydrogen'
+import { useWeaverse, type WeaverseHydrogen } from '@weaverse/hydrogen'
 
 export function NavigationControls() {
-  const { itemInstances } = useWeaverse()
-  
-  // Access header and announcement bar instances directly
+  const { itemInstances } = useWeaverse<WeaverseHydrogen>()
+
   const header = itemInstances.get('site-header')
   const announcementBar = itemInstances.get('announcement-bar')
-  
+
   const toggleAnnouncementBar = () => {
     if (announcementBar) {
-      announcementBar.updateData({
-        isVisible: !announcementBar.data.isVisible
+      announcementBar.setData({
+        isVisible: !announcementBar.data.isVisible,
       })
     }
   }
-  
+
   const toggleStickyHeader = () => {
     if (header) {
-      header.updateData({
-        isSticky: !header.data.isSticky
+      header.setData({
+        isSticky: !header.data.isSticky,
       })
     }
   }
-  
+
   return (
     <div className="nav-controls">
       <button onClick={toggleAnnouncementBar}>
@@ -71,15 +70,15 @@ export function NavigationControls() {
 
 ### Accessing Page Data
 
-Get access to the current page's data structure:
+Specify `WeaverseHydrogen` to get the Hydrogen page data type:
 
 ```tsx
-import { useWeaverse } from '@weaverse/hydrogen'
+import { useWeaverse, type WeaverseHydrogen } from '@weaverse/hydrogen'
 
 export function PageInfo() {
-  const { data } = useWeaverse()
+  const { data } = useWeaverse<WeaverseHydrogen>()
   const { id, name, items } = data
-  
+
   return (
     <div className="page-info">
       <h1>Current Page: {name}</h1>
@@ -94,23 +93,20 @@ export function PageInfo() {
 
 ### `itemInstances`
 
-- **Type**: `Map<string, WeaverseItemStore>`
-- **Description**: Registry of all component instances available in the current page
+Registry mapping component instance IDs to their item stores.
 
 ### `data`
 
-- **Type**: `HydrogenPageData`
-- **Description**: Current page data including its ID, name, and component items
+The current project data. For `WeaverseHydrogen`, this is `HydrogenPageData`, which includes the page ID, name, root ID, and component items.
 
 ### `elementRegistry`
 
-- **Type**: `Map<string, HTMLElement>`
-- **Description**: Registry mapping component IDs to their DOM elements
+Registry mapping component **types** to their registered component definitions. It is not a registry of DOM elements or component instance IDs.
 
 ## When To Use
 
-- When you need to find and interact with components that aren't in the current component tree
-- When you need access to page-level configuration data
+- When you need to find and interact with components outside the current component tree
+- When you need access to page-level runtime data
 
 ## Related
 

--- a/api-reference/weaverse-client.mdx
+++ b/api-reference/weaverse-client.mdx
@@ -1,27 +1,26 @@
 ---
 title: WeaverseClient
-description: The WeaverseClient class provides server-side methods to interact with Weaverse content and services in a Hydrogen storefront.
+description: Server-side client for loading Weaverse content in Shopify Hydrogen.
 published: true
 ---
 
 # WeaverseClient
 
-The `WeaverseClient` class is a server-side utility that provides methods to interact with Weaverse services, fetch content, manage caching strategies, and load theme settings and page data for your Hydrogen storefront.
+`WeaverseClient` loads Weaverse page data, theme settings, and custom page metadata on the server. It also runs registered component loaders and integrates with Hydrogen caching.
 
 ## Initialization
 
-The `WeaverseClient` is typically initialized in your `server.ts` file and injected into your app's load context:
+Create the client in your app load context:
 
 ```tsx
-// Example from templates/pilot/server.ts
+import { WeaverseClient } from '@weaverse/hydrogen'
+
 export async function createAppLoadContext(
   request: Request,
   env: Env,
-  executionContext: ExecutionContext,
+  executionContext: ExecutionContext
 ) {
-  // ... other context setup
-
-  let hydrogenContext = createHydrogenContext({
+  const hydrogenContext = createHydrogenContext({
     env,
     request,
     cache,
@@ -29,7 +28,7 @@ export async function createAppLoadContext(
     session,
     i18n: getLocaleFromRequest(request),
     cart: { queryFragment: CART_QUERY_FRAGMENT },
-  });
+  })
 
   return {
     ...hydrogenContext,
@@ -39,382 +38,241 @@ export async function createAppLoadContext(
       cache,
       themeSchema,
       components,
+      // Optional: override env-based project resolution
+      projectId: env.WEAVERSE_PROJECT_ID,
+      // Optional: request timeout in milliseconds
+      fetchTimeoutMs: 10_000,
     }),
-  };
+  }
 }
 ```
 
-Refer to the [Project Structure guide](core-concepts/project-structure#base-files-explained) for a detailed setup walkthrough.
+See the [Project Structure guide](/core-concepts/project-structure#base-files-explained) for the complete setup.
 
-## Type Definition
+## Public API
 
 ```typescript
 class WeaverseClient {
-  constructor(args: WeaverseClientArgs);
-  
-  // Properties
-  public API: string;  // API endpoint path
-  public basePageConfigs: Omit<WeaverseProjectConfigs, 'requestInfo'>
-  public basePageRequestBody: Omit<FetchProjectRequestBody, 'url'>
-  public configs: WeaverseProjectConfigs
-  public storefront: HydrogenContext['storefront'];
-  public env: HydrogenEnv;
-  public cache: Cache;
-  public waitUntil: ExecutionContext['waitUntil'];
-  public request: Request;
-  public components: HydrogenComponent[];
-  public themeSchema: HydrogenThemeSchema;
-  
-  // Methods
-  fetchWithCache<T>(url: string, options?: RequestInit & { strategy?: AllCacheOptions }): Promise<T>;
-  loadThemeSettings(strategy?: AllCacheOptions): Promise<HydrogenThemeSettings>;
-  loadPage(params?: { type?: PageType, locale?: string, handle?: string, projectId?: string, strategy?: AllCacheOptions }): Promise<WeaverseLoaderData | null>;
-  execComponentLoader(item: HydrogenComponentData): Promise<HydrogenComponentData>;
-  generateFallbackPage(message: string): HydrogenPageData;
+  constructor(args: WeaverseClientArgs)
+
+  API: 'v1'
+  basePageConfigs: Omit<WeaverseProjectConfigs, 'requestInfo'>
+  basePageRequestBody: Omit<FetchProjectRequestBody, 'url'>
+  configs: WeaverseProjectConfigs
+  storefront: WeaverseClientArgs['storefront']
+  customerAccount: WeaverseClientArgs['customerAccount']
+  env: WeaverseClientArgs['env']
+  cache: WeaverseClientArgs['cache']
+  waitUntil: WeaverseClientArgs['waitUntil']
+  request: WeaverseClientArgs['request']
+  components: WeaverseClientArgs['components']
+  themeSchema: WeaverseClientArgs['themeSchema']
+  withCache: ReturnType<typeof createWithCache>
+
+  fetchWithCache<T>(
+    url: string,
+    options?: WeaverseFetchWithCacheOptions
+  ): Promise<T>
+  fetchCustomPages(options?: FetchCustomPagesOptions): Promise<CustomPageEntry[]>
+  loadThemeSettings(strategy?: CachingStrategy): Promise<ThemeSettingsResponse>
+  loadPage(params?: LoadPageParams): Promise<WeaverseLoaderData | null>
+  execComponentLoader(item: HydrogenComponentData): Promise<HydrogenComponentData>
+  generateFallbackPage(message: string): HydrogenPageData
 }
 
 type WeaverseClientArgs = HydrogenContext & {
-  components: HydrogenComponent[];
-  themeSchema: HydrogenThemeSchema;
-  request: Request;
-  cache: Cache;
-};
+  components: HydrogenComponent[]
+  themeSchema: HydrogenThemeSchema
+  request: Request
+  cache: Cache
+  projectId?: string | (() => string) | (() => Promise<string>)
+  fetchTimeoutMs?: number
+}
 ```
+
+`API` is the current API version segment (`'v1'`), not a complete endpoint URL.
 
 ## Methods
 
-### fetchWithCache
+### `fetchWithCache`
 
-Fetches data from an external API with configurable caching strategies.
+Fetch data through Hydrogen's cache integration:
 
 ```typescript
-fetchWithCache<T>(url: string, options?: RequestInit & { strategy?: AllCacheOptions }): Promise<T>
+fetchWithCache<T>(
+  url: string,
+  options?: RequestInit & {
+    cacheTarget?: BuilderApiCacheTarget
+    strategy?: CachingStrategy
+  }
+): Promise<T>
 ```
 
-**Parameters:**
-- `url: string` - The endpoint URL
-- `options?: RequestInit & { strategy?: AllCacheOptions }` - Cache and fetch configuration
-  - `strategy` - Caching strategy with options like `maxAge`, `staleWhileRevalidate`, etc.
-  - Other standard `fetch` options (`headers`, `method`, etc.)
-
-**Returns:**
-- `Promise<T>` - A promise that resolves with the fetched data
-
-**Example:**
-
 ```typescript
-// In a component loader
-export async function loader({ data, weaverse }: ComponentLoaderArgs) {
-  const apiUrl = 'https://api.example.com/products';
-  
-  const products = await weaverse.fetchWithCache(apiUrl, {
-    headers: {
-      'Authorization': `Bearer ${process.env.API_KEY}`
-    },
-    cache: {
-      maxAge: 60, // Cache for 60 seconds
-      staleWhileRevalidate: 600 // Allow stale content for 10 minutes while revalidating
+export async function loader({ weaverse }: ComponentLoaderArgs) {
+  const products = await weaverse.fetchWithCache<Product[]>(
+    'https://api.example.com/products',
+    {
+      strategy: {
+        maxAge: 60,
+        staleWhileRevalidate: 600,
+      },
     }
-  });
-  
-  return { products };
+  )
+
+  return { products }
 }
 ```
 
-Refer to the [Data Fetching and Caching guide](/development-guide/data-fetching#fetching-data-from-external-apis) for more details.
+Use `strategy`, not the Fetch API `cache` property, for Hydrogen cache-control options.
 
-### loadThemeSettings
-
-Loads the global theme settings for the current Weaverse project.
+### `loadThemeSettings`
 
 ```typescript
-loadThemeSettings(strategy?: AllCacheOptions): Promise<HydrogenThemeSettings>
+loadThemeSettings(
+  strategy?: CachingStrategy
+): Promise<ThemeSettingsResponse>
 ```
 
-**Parameters:**
-- `strategy?: AllCacheOptions` - Optional caching strategy for the theme settings request
-
-**Returns:**
-- `Promise<HydrogenThemeSettings>` - The theme settings object
-
-**Example:**
+The response can contain:
 
 ```typescript
-// In a route loader
-export async function loader({ context }: LoaderFunctionArgs) {
-  const { weaverse } = context;
-  const themeSettings = await weaverse.loadThemeSettings();
-  
-  return json({
-    themeSettings,
-    // other data
-  });
+type ThemeSettingsResponse = {
+  theme?: HydrogenThemeSettings
+  schema?: HydrogenThemeSchema
+  publicEnv?: PublicEnv
+  staticContent?: Record<string, unknown>
+  merchantOverrides?: Record<string, unknown>
+  _error?: string
+  _loadFailed?: boolean
 }
 ```
 
-### loadPage
+Return the complete response under `weaverseTheme` from the root loader so `withWeaverse` can initialize theme and translation stores:
 
-Loads a page's data from Weaverse, including running component loaders and handling localization.
+```typescript
+export async function loader({ context }: Route.LoaderArgs) {
+  return {
+    weaverseTheme: await context.weaverse.loadThemeSettings(),
+  }
+}
+```
+
+Read settings directly from the response with `response.theme`.
+
+### `loadPage`
 
 ```typescript
 loadPage(params?: {
-  type?: PageType,
-  locale?: string,
-  handle?: string,
-  projectId?: string,
-  strategy?: AllCacheOptions
+  type?: PageType
+  locale?: string
+  handle?: string
+  strategy?: CachingStrategy
+  projectId?: string
 }): Promise<WeaverseLoaderData | null>
 ```
 
-**Parameters:**
+#### `type`
 
-<AccordionGroup>
-  <Accordion title="type?: PageType" icon="file" defaultOpen>
-    Page type identifier determining the kind of content to load.
+Supported `PageType` values:
 
-    **Supported types:**
-    - `'INDEX'` - Homepage
-    - `'PRODUCT'` - Product detail pages
-    - `'COLLECTION'` - Collection/category pages
-    - `'PAGE'` - Custom pages created in Weaverse Studio
-    - `'BLOG'` - Blog listing pages
-    - `'ARTICLE'` - Individual blog post pages
-    - `'CUSTOM'` - Dynamic custom pages
+- `'*'`
+- `'INDEX'`
+- `'PRODUCT'`
+- `'ALL_PRODUCTS'`
+- `'COLLECTION'`
+- `'COLLECTION_LIST'`
+- `'PAGE'`
+- `'BLOG'`
+- `'ARTICLE'`
+- `'CUSTOM'`
 
-    **Default:** Inferred from route context if not specified.
+When omitted, the content service resolves the page from the request URL and project configuration.
 
-    **Required:** For most page types except INDEX and CUSTOM.
-  </Accordion>
+#### `locale`
 
-  <Accordion title="locale?: string" icon="globe">
-    Locale identifier for loading localized content.
+An optional BCP 47 locale override such as `en-US`, `sv-SE`, or `fr-CA`. The value is forwarded unchanged. When omitted, the request uses `context.storefront.i18n`; `loadPage()` does not implement its own URL-prefix detection or `en-us` fallback.
 
-    **Format:** `language-country` (lowercase, hyphen-separated)
-    - Language: ISO 639-1 code (2 letters, e.g., `sv`, `en`, `fr`)
-    - Country: ISO 3166-1 alpha-2 code (2 letters, e.g., `se`, `us`, `ca`)
+#### `handle`
 
-    **Examples:**
-    - `"en-us"` - English in United States
-    - `"sv-se"` - Swedish (sv) in Sweden (se)
-    - `"fr-ca"` - French (fr) in Canada (ca)
-    - `"de-de"` - German (de) in Germany (de)
+The resource or custom-page handle used with page types such as `PRODUCT`, `COLLECTION`, `PAGE`, `BLOG`, and `ARTICLE`.
 
-    **Detection priority when not provided:**
-    1. Path prefix from URL (deprecated)
-    2. Auto-detection from `context.storefront.i18n.pathPrefix`
+#### `projectId`
 
-    **Fallback:** If the specified locale doesn't exist, falls back to `en-us` (smart fallback coming in future release).
+Overrides the client's resolved project ID for this request. Constructor-level `projectId` can also be a synchronous or asynchronous function for multi-project storefronts.
 
-    **When to use explicit locale:**
-    - Custom routing logic determines locale
-    - Loading content for different locale than current page
-    - Background jobs without request context
-    - Cross-locale content comparison
+#### `strategy`
 
-    See [Advanced Localization Guide](/guides/localization-advanced) for complete details.
-  </Accordion>
-
-  <Accordion title="handle?: string" icon="tag">
-    Page handle/slug identifier for specific content.
-
-    **Required for:**
-    - `PRODUCT` - Product handle (e.g., `"classic-varsity-jacket"`)
-    - `COLLECTION` - Collection handle (e.g., `"summer-collection"`)
-    - `PAGE` - Custom page handle from Studio
-    - `BLOG` - Blog handle
-    - `ARTICLE` - Article handle
-
-    **Not used for:**
-    - `INDEX` - Homepage (no handle needed)
-    - `CUSTOM` - Dynamic custom pages (URL determines content)
-
-    **Format:** URL-friendly slug (lowercase, hyphens, no spaces)
-  </Accordion>
-
-  <Accordion title="projectId?: string" icon="folder-tree">
-    Weaverse project ID for multi-project architectures.
-
-    **Default:** Value from `WEAVERSE_PROJECT_ID` environment variable
-
-    **When to use:**
-    - Multi-brand storefronts sharing infrastructure
-    - Different projects per market or locale
-    - A/B testing different project configurations
-    - Staging vs production project separation
-
-    **Example use case:** Domain-based project selection
-    ```typescript
-    let projectId = origin === "https://store.se"
-      ? "project-sweden-123"
-      : "project-default-456";
-
-    let data = await weaverse.loadPage({ type: "INDEX", projectId });
-    ```
-
-    **Important:** Set up `projectId` in WeaverseClient initialization for automatic domain-based routing. Route-level override is available for special cases.
-
-    See [Multi-Project Architecture Guide](/guides/multi-project-architecture) for comprehensive implementation details, including A/B testing, multi-brand setups, and step-by-step migration guides.
-  </Accordion>
-
-  <Accordion title="strategy?: AllCacheOptions" icon="database">
-    Caching strategy configuration for the page data request.
-
-    **Options:**
-    - `mode?` - Cache control mode: `'public'`, `'private'`, `'no-cache'`, `'no-store'`, `'must-revalidate'`
-    - `maxAge?` - Cache duration in seconds
-    - `staleWhileRevalidate?` - Serve stale content while revalidating in seconds
-    - `sMaxAge?` - Shared cache (CDN) duration in seconds
-    - `staleIfError?` - Serve stale content if error occurs in seconds
-
-    **Example:**
-    ```typescript
-    strategy: {
-      mode: "public",
-      maxAge: 3600, // Cache for 1 hour
-      staleWhileRevalidate: 86400, // Serve stale for 24h while updating
-      sMaxAge: 7200, // CDN cache for 2 hours
-      staleIfError: 604800, // Serve stale for 7 days if error
-    }
-    ```
-  </Accordion>
-</AccordionGroup>
-
-**Returns:**
-- `Promise<WeaverseLoaderData | null>` - Page data object or `null` if not found
-
-**Examples:**
-
-<CodeGroup>
-```typescript Basic Usage
-// Auto-detects locale from context.storefront.i18n
-export async function loader({ context, params }: LoaderFunctionArgs) {
-  let { weaverse } = context;
-
-  let weaverseData = await weaverse.loadPage({
-    type: "PRODUCT",
-    handle: params.productHandle,
-  });
-
-  return { weaverseData };
-}
-```
-
-```typescript With Explicit Locale
-// Load Swedish content explicitly
-export async function loader({ context, params }: LoaderFunctionArgs) {
-  let { weaverse } = context;
-
-  let weaverseData = await weaverse.loadPage({
-    type: "PRODUCT",
-    handle: params.productHandle,
-    locale: "sv-se", // Swedish (sv) in Sweden (se)
-  });
-
-  return { weaverseData };
-}
-```
-
-```typescript Cross-Locale Loading
-// Load content in multiple locales
-export async function loader({ context, params }: LoaderFunctionArgs) {
-  let { weaverse } = context;
-  let { productHandle } = params;
-
-  let [englishData, frenchData, swedishData] = await Promise.all([
-    weaverse.loadPage({ type: "PRODUCT", handle: productHandle, locale: "en-us" }),
-    weaverse.loadPage({ type: "PRODUCT", handle: productHandle, locale: "fr-ca" }),
-    weaverse.loadPage({ type: "PRODUCT", handle: productHandle, locale: "sv-se" }),
-  ]);
-
-  return { englishData, frenchData, swedishData };
-}
-```
-
-```typescript Multi-Project Setup
-// Load from different project based on domain
-export async function loader({ context, request, params }: LoaderFunctionArgs) {
-  let { weaverse } = context;
-  let origin = new URL(request.url).origin;
-
-  // Determine project by domain
-  let projectId = origin === "https://mystore.se"
-    ? "project-sweden-123"
-    : "project-default-456";
-
-  let weaverseData = await weaverse.loadPage({
-    type: "PRODUCT",
-    handle: params.productHandle,
-    projectId, // Override default project
-  });
-
-  return { weaverseData };
-}
-```
-
-```typescript Complete Example
-// All parameters with error handling
-export async function loader({ context, request, params }: LoaderFunctionArgs) {
-  let { weaverse } = context;
-
-  // Determine locale from custom logic
-  let locale = params.locale?.toLowerCase() || "en-us";
-
-  let weaverseData = await weaverse.loadPage({
-    type: "PRODUCT",
-    handle: params.productHandle,
-    locale,
-    strategy: {
-      maxAge: 3600,              // Cache for 1 hour
-      staleWhileRevalidate: 86400 // Stale-while-revalidate for 24h
-    }
-  });
-
-  if (!weaverseData) {
-    throw new Response("Page not found", { status: 404 });
-  }
-
-  return { weaverseData, locale };
-}
-```
-</CodeGroup>
-
-**Related:**
-- [Rendering Weaverse Pages](/guides/rendering-page) - Complete guide to page rendering
-- [Advanced Localization](/guides/localization-advanced) - Locale detection and multi-project setup
-- [Multi-Project Architecture](/guides/multi-project-architecture) - A/B testing, multi-brand, and advanced routing
-- [Markets & Localization](/features/markets-localization) - Studio workflow for localized content
-
-### execComponentLoader
-
-Executes a component's loader function to fetch its data.
+A Hydrogen `CachingStrategy`, for example:
 
 ```typescript
-execComponentLoader(item: HydrogenComponentData): Promise<HydrogenComponentData>
+strategy: {
+  mode: 'public',
+  maxAge: 3600,
+  staleWhileRevalidate: 86400,
+  sMaxAge: 7200,
+  staleIfError: 604800,
+}
 ```
 
-**Parameters:**
-- `item: HydrogenComponentData` - Component data object
+#### Example
 
-**Returns:**
-- `Promise<HydrogenComponentData>` - Component data with loader data added
+```typescript
+export async function loader({ context, params }: Route.LoaderArgs) {
+  const weaverseData = await context.weaverse.loadPage({
+    type: 'PRODUCT',
+    handle: params.productHandle,
+    locale: 'en-US',
+  })
 
-**Note:** This method is primarily used internally by `loadPage` to process component loaders.
+  if (!weaverseData) {
+    throw new Response('Weaverse page load failed', { status: 500 })
+  }
 
-### generateFallbackPage
+  return { weaverseData }
+}
+```
 
-Generates a fallback page when the requested page data isn't available.
+A missing page payload is normalized into a fallback page. `null` indicates that loading or validation failed; do not treat it as a reliable page-not-found signal.
+
+### `fetchCustomPages`
+
+```typescript
+fetchCustomPages(options?: {
+  limit?: number
+  locale?: string
+}): Promise<CustomPageEntry[]>
+```
+
+Fetches published custom-page entries for sitemap and route-generation workflows.
+
+```typescript
+const pages = await context.weaverse.fetchCustomPages({
+  locale: 'en-US',
+  limit: 100,
+})
+```
+
+### `execComponentLoader`
+
+```typescript
+execComponentLoader(
+  item: HydrogenComponentData
+): Promise<HydrogenComponentData>
+```
+
+Runs the registered loader for one component and attaches its loader data. `loadPage()` calls this internally.
+
+### `generateFallbackPage`
 
 ```typescript
 generateFallbackPage(message: string): HydrogenPageData
 ```
 
-**Parameters:**
-- `message: string` - Message to display on the fallback page
-
-**Returns:**
-- `HydrogenPageData` - A basic page data object with the message
+Creates the page structure used when the content response does not include page data.
 
 ## Related
 
-- [useWeaverse](/api-reference/use-weaverse) - Hook for accessing Weaverse instance client-side
-- [Data Fetching and Caching](/development-guide/data-fetching) - Advanced guide on data fetching
+- [WeaverseHydrogenRoot](/api-reference/weaverse-root) - Render loader data
+- [withWeaverse](/api-reference/with-weaverse) - Initialize root theme and Studio providers
+- [Data Fetching and Caching](/development-guide/data-fetching) - Component data loading

--- a/api-reference/weaverse-root.mdx
+++ b/api-reference/weaverse-root.mdx
@@ -1,107 +1,112 @@
 ---
-title: WeaverseRoot
-description: The core rendering component for Weaverse content in React-based applications.
+title: WeaverseHydrogenRoot
+description: Render Weaverse page data in a Shopify Hydrogen route.
 published: true
 ---
 
-# WeaverseRoot
+# WeaverseHydrogenRoot
 
-The `WeaverseRoot` component is the primary renderer for Weaverse content in React applications. It serves as the entry point for rendering dynamic, data-driven Weaverse components based on the provided Weaverse context.
+`WeaverseHydrogenRoot` is the public Hydrogen renderer. It resolves `weaverseData` from the current React Router route, creates the Weaverse runtime, registers your theme components, and renders the page tree.
 
 ## Import
 
 ```tsx
-import { WeaverseRoot } from '@weaverse/hydrogen'
+import { WeaverseHydrogenRoot } from '@weaverse/hydrogen'
 ```
+
+<Note>
+  The lower-level `WeaverseRoot` component belongs to `@weaverse/react` and requires an initialized `Weaverse` runtime. Hydrogen applications should use `WeaverseHydrogenRoot` instead.
+</Note>
+
+## Type
+
+```typescript
+interface WeaverseHydrogenRootProps {
+  components: HydrogenComponent[]
+  data?: WeaverseLoaderData | Promise<WeaverseLoaderData> | null
+  errorComponent?: React.FC<{ error: Error | unknown }>
+}
+```
+
+## Basic Usage
+
+Return `weaverseData` from the route loader. The component automatically reads the closest route's loader data:
+
+```tsx
+import { WeaverseHydrogenRoot } from '@weaverse/hydrogen'
+import type { Route } from './+types/$'
+import { components } from '~/weaverse/components'
+
+export async function loader({ context }: Route.LoaderArgs) {
+  return {
+    weaverseData: await context.weaverse.loadPage(),
+  }
+}
+
+export default function WeaversePage() {
+  return <WeaverseHydrogenRoot components={components} />
+}
+```
+
+## Passing Data Explicitly
+
+Use the `data` prop when a layout and child route render different Weaverse pages on the same URL:
+
+```tsx
+import { WeaverseHydrogenRoot } from '@weaverse/hydrogen'
+import { useLoaderData } from 'react-router'
+import type { Route } from './+types/$'
+import { components } from '~/weaverse/components'
+
+export async function loader({ context }: Route.LoaderArgs) {
+  return {
+    weaverseData: await context.weaverse.loadPage(),
+  }
+}
+
+export default function WeaversePage() {
+  const { weaverseData } = useLoaderData<typeof loader>()
+
+  return (
+    <WeaverseHydrogenRoot
+      components={components}
+      data={weaverseData}
+    />
+  )
+}
+```
+
+The `data` prop accepts a resolved value or a promise. Passing `null` explicitly suppresses rendering.
 
 ## Props
 
-| Prop | Type | Description |
-| --- | --- | --- |
-| `context` | `Weaverse` | The Weaverse instance containing the project data and component registry. |
+### `components`
 
-## Type Definition
+- **Type**: `HydrogenComponent[]`
+- **Required**: Yes
+- **Description**: Component definitions available to the page renderer.
 
-```typescript
-interface WeaverseRootPropsType {
-  context: Weaverse;
-}
+### `data`
 
-const WeaverseRoot: React.FC<WeaverseRootPropsType>;
-```
+- **Type**: `WeaverseLoaderData | Promise<WeaverseLoaderData | null> | null`
+- **Required**: No
+- **Description**: Overrides automatic route-scoped `weaverseData` resolution. Promises are handled with React Router's `<Await>`.
 
-## Usage
+### `errorComponent`
 
-```tsx
-import { WeaverseRoot, useWeaverse } from '@weaverse/hydrogen'
+- **Type**: `React.FC<{ error: Error | unknown }>`
+- **Required**: No
+- **Description**: Rendered when page data cannot be resolved or rendering throws.
 
-export function App() {
-  const weaverse = useWeaverse()
-  
-  return (
-    <div className="app-container">
-      <Header />
-      <main>
-        <WeaverseRoot context={weaverse} />
-      </main>
-      <Footer />
-    </div>
-  )
-}
-```
+## Behavior
 
-## How It Works
-
-The `WeaverseRoot` component:
-
-1. Creates a React context provider that makes the Weaverse instance available throughout the component tree
-2. Renders the root component from the Weaverse project data
-3. Sets up the necessary DOM structure with data attributes for Weaverse Studio integration
-4. Establishes the component tree based on parent-child relationships defined in the project data
-5. Passes appropriate props and data to each component in the tree
-
-## Rendering Process
-
-1. The component subscribes to changes in the Weaverse instance using `useSyncExternalStore`
-2. It renders a container element with appropriate Weaverse data attributes
-3. It finds the root component ID from the Weaverse data
-4. It recursively renders each component in the tree using internal `ItemInstance` and `ItemComponent` components
-5. Each component receives its data and children components based on the Weaverse project structure
-
-## Example: Full Page Structure
-
-```tsx
-import { WeaverseRoot } from '@weaverse/hydrogen'
-import { useLoaderData } from '@remix-run/react'
-
-export default function Page() {
-  const { weaverseData } = useLoaderData()
-  
-  return (
-    <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
-        <title>My Weaverse App</title>
-      </head>
-      <body>
-        <WeaverseRoot context={weaverseData} />
-      </body>
-    </html>
-  )
-}
-```
-
-## Notes
-
-- Only one `WeaverseRoot` component should be used per page
-- The component automatically handles the entire component tree rendering
-- No need to manually render children - the component handles parent-child relationships
-- The component adds necessary data attributes for Weaverse Studio integration
-- Returns `null` if no valid Weaverse context or project ID is provided
+- The closest route's `weaverseData` is used when `data` is omitted.
+- Multiple roots are supported for nested layouts and child routes.
+- `data={null}` returns `null` without rendering an error.
+- Missing automatically resolved data renders `errorComponent`.
 
 ## Related
 
-- [useWeaverse](/api-reference/use-weaverse) - Hook to access the Weaverse instance
-- WeaverseHydrogenRoot - Hydrogen-specific wrapper around WeaverseRoot
-- [useItemInstance](/api-reference/use-item-instance) - Access component instances in the tree
+- [withWeaverse](/api-reference/with-weaverse) - Set up root theme, translation, and Studio integration
+- [WeaverseClient](/api-reference/weaverse-client) - Load page and theme data
+- [useWeaverse](/api-reference/use-weaverse) - Access the active runtime

--- a/api-reference/weaverse-root.mdx
+++ b/api-reference/weaverse-root.mdx
@@ -23,7 +23,7 @@ import { WeaverseHydrogenRoot } from '@weaverse/hydrogen'
 ```typescript
 interface WeaverseHydrogenRootProps {
   components: HydrogenComponent[]
-  data?: WeaverseLoaderData | Promise<WeaverseLoaderData> | null
+  data?: WeaverseLoaderData | Promise<WeaverseLoaderData | null> | null
   errorComponent?: React.FC<{ error: Error | unknown }>
 }
 ```

--- a/api-reference/with-weaverse.mdx
+++ b/api-reference/with-weaverse.mdx
@@ -1,38 +1,94 @@
 ---
 title: withWeaverse
-description: The withWeaverse HOC enhances your root component, allowing it to access Weaverse-specific properties and methods.
+description: Wrap a React Router root Layout with Weaverse theme, translation, and Studio integration.
 published: true
 ---
 
-**`withWeaverse`** HOC is a crucial part of the architecture. It wraps the root component and any error boundaries to
-ensure that Weaverse functionalities are available throughout the application.
+# withWeaverse
 
-## Usage
+`withWeaverse` wraps the root route `Layout` with the theme settings store, translation provider, and Studio connection bridge.
 
-Implement **`withWeaverse`** in your root component and error boundary components to provide them with Weaverse
-integration. This process allows the components to access the loaded Weaverse theme settings and other context-specific
-data provided by Weaverse.
+Use it on `Layout`, not only on the default route component. React Router keeps `Layout` mounted around both the matched route and `ErrorBoundary`, so the Studio connection remains available during loader, render, and 404 errors.
 
-Here's a basic example of how to wrap your root component with **`withWeaverse`**:
+## Import
 
 ```tsx
 import { withWeaverse } from '@weaverse/hydrogen'
+```
 
-function App() {
-  // Your component logic
+## Type
+
+```typescript
+type WithWeaverseOptions = {
+  t?: TranslateFunction
 }
 
-export default withWeaverse(App)
+function withWeaverse(
+  Component: React.ComponentType<any>,
+  options?: WithWeaverseOptions
+): (props: React.JSX.IntrinsicAttributes) => React.JSX.Element
 ```
 
-Similarly, for an error boundary component:
+## Root Loader Requirement
+
+Return the result of `loadThemeSettings()` under the `weaverseTheme` key in the root loader:
 
 ```tsx
-export const ErrorBoundary = withWeaverse(ErrorBoundaryComponent)
+import type { Route } from './+types/root'
+
+export async function loader({ context }: Route.LoaderArgs) {
+  return {
+    weaverseTheme: await context.weaverse.loadThemeSettings(),
+  }
+}
 ```
 
-## How It Works
+The theme store reads `weaverseTheme.theme`, while the translation provider also uses `staticContent` and `merchantOverrides` from this response.
 
-By wrapping a component with **`withWeaverse`**, the component gains access to the Weaverse context, which includes
-theme settings, page configurations, and other essential data loaded via the Weaverse client. This allows for consistent
-use of Weaverse features across the entire app.
+## Usage
+
+Export the wrapped component as the root route `Layout`:
+
+```tsx
+import { withWeaverse } from '@weaverse/hydrogen'
+import type { ReactNode } from 'react'
+
+function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export const Layout = withWeaverse(RootLayout)
+```
+
+Do not wrap the default route component and `ErrorBoundary` separately. When an error occurs, React Router replaces the default component but keeps `Layout` mounted.
+
+## External Translation Function
+
+Pass a translation function through the optional second argument when integrating another i18n system:
+
+```tsx
+export const Layout = withWeaverse(RootLayout, { t })
+```
+
+The provided function has the highest priority in the translation resolution chain.
+
+## What It Provides
+
+`withWeaverse` mounts:
+
+- `ThemeSettingsStoreContext`
+- `TranslationProvider`
+- `StudioConnect`
+
+It does **not** create the page-level `WeaverseContext`. That runtime context is created by `WeaverseHydrogenRoot` when it renders a page.
+
+## Related
+
+- [WeaverseHydrogenRoot](/api-reference/weaverse-root) - Render the Weaverse page runtime
+- [useThemeSettings](/api-reference/use-theme-settings) - Read global theme settings
+- [WeaverseClient](/api-reference/weaverse-client) - Load root theme settings


### PR DESCRIPTION
## Summary

- align hook and item-store examples with the current runtime APIs
- document the supported Hydrogen root and `withWeaverse` integration patterns
- sync client, types, utilities, and overview pages with Weaverse SDK v5.19.1 (`f452a746`)

## Validation

- `mint validate`
- local preview smoke test for all 11 changed routes
- `mint broken-links` reports only the pre-existing `resources/faq.mdx` → `/docs` link
